### PR TITLE
Using Concurrency Support of PinnedVec

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,18 +1,18 @@
 [package]
 name = "orx-concurrent-bag"
-version = "1.5.0"
+version = "1.6.0"
 edition = "2021"
 authors = ["orxfun <orx.ugur.arikan@gmail.com>"]
 description = "An efficient, convenient and lightweight grow-only concurrent collection, ideal for collecting results concurrently."
 license = "MIT"
 repository = "https://github.com/orxfun/orx-concurrent-bag/"
-keywords = ["concurrency", "bag", "data-structures", "collect"]
+keywords = ["concurrency", "bag", "data-structures", "atomic", "lock-free"]
 categories = ["data-structures", "concurrency", "rust-patterns"]
 
 [dependencies]
-orx-fixed-vec = "2.5"
-orx-pinned-vec = "2.5"
-orx-split-vec = "2.6"
+orx-fixed-vec = "2.6.1"
+orx-pinned-vec = "2.6"
+orx-split-vec = "2.7"
 
 
 [dev-dependencies]

--- a/README.md
+++ b/README.md
@@ -4,55 +4,14 @@
 [![orx-concurrent-bag documentation](https://docs.rs/orx-concurrent-bag/badge.svg)](https://docs.rs/orx-concurrent-bag)
 
 An efficient, convenient and lightweight grow-only concurrent collection, ideal for collecting results concurrently.
-* **convenient**: the bag can be shared among threads simply as a shared reference, not even requiring `Arc`,
-* **efficient**: for collecting results concurrently:
-  * rayon is significantly faster when the elements are small and there is an extreme load (no work at all among push calls);
-  * `ConcurrentBag` starts to perform faster as elements or the computation in between push calls get larger (see <a href="#section-benchmarks">E. Benchmarks</a> for the experiments).
-* **lightweight**: due to the simplistic approach taken, it enables concurrent programs with smaller binary sizes.
 
-The bag preserves the order of elements with respect to the order the `push` method is called.
+* **convenient**: `ConcurrentBag` can safely be shared among threads simply as a shared reference. Further, it is just a wrapper around any [`PinnedVec`](https://crates.io/crates/orx-pinned-vec) implementation adding concurrent safety guarantees. Therefore, underlying pinned vector and concurrent bag can be converted to each other back and forth without any cost.
+* **lightweight**: This crate takes a simplistic approach built on pinned vector guarantees which leads to concurrent programs with few dependencies and small binaries (see <a href="#section-approach-and-safety">approach and safety</a> for details).
+* **efficient**: `ConcurrentBag` is a lock free structure making use of a few atomic primitives. rayon is significantly faster when collecting small results under an extreme load (negligible work to compute results); however, `ConcurrentBag` starts to perform faster as result types get larger (see <a href="#section-benchmarks">benchmarks</a> for the experiments).
 
 # Examples
 
-Safety guarantees to push to the bag with an immutable reference makes it easy to share the bag among threads.
-
-## Using `std::sync::Arc`
-
-We can share our bag among threads using `Arc` and collect results concurrently.
-
-```rust
-use orx_concurrent_bag::*;
-use std::{sync::Arc, thread};
-
-let (num_threads, num_items_per_thread) = (4, 8);
-
-let bag = Arc::new(ConcurrentBag::new());
-let mut thread_vec: Vec<thread::JoinHandle<()>> = Vec::new();
-
-for i in 0..num_threads {
-    let bag = bag.clone();
-    thread_vec.push(thread::spawn(move || {
-        for j in 0..num_items_per_thread {
-            // concurrently collect results simply by calling `push`
-            bag.push(i * 1000 + j);
-        }
-    }));
-}
-
-for handle in thread_vec {
-    handle.join().unwrap();
-}
-
-let mut vec_from_bag: Vec<_> = unsafe { bag.iter() }.copied().collect();
-vec_from_bag.sort();
-let mut expected: Vec<_> = (0..num_threads).flat_map(|i| (0..num_items_per_thread).map(move |j| i * 1000 + j)).collect();
-expected.sort();
-assert_eq!(vec_from_bag, expected);
-```
-
-## Using `std::thread::scope`
-
-An even more convenient approach would be to use thread scopes. This allows to use shared reference of the bag across threads, instead of `Arc`.
+Safety guarantees to push to the bag with an immutable reference makes it easy to share the bag among threads. `std::sync::Arc` can be used; however, it is not required as demonstrated below.
 
 ```rust
 use orx_concurrent_bag::*;
@@ -60,7 +19,8 @@ use orx_concurrent_bag::*;
 let (num_threads, num_items_per_thread) = (4, 8);
 
 let bag = ConcurrentBag::new();
-let bag_ref = &bag; // just take a reference
+let bag_ref = &bag; // just take a reference and share among threads
+
 std::thread::scope(|s| {
     for i in 0..num_threads {
         s.spawn(move || {
@@ -79,28 +39,84 @@ expected.sort();
 assert_eq!(vec_from_bag, expected);
 ```
 
-# Safety
+<div id="section-approach-and-safety"></div>
 
-`ConcurrentBag` uses a [`PinnedVec`](https://crates.io/crates/orx-pinned-vec) implementation as the underlying storage (see [`SplitVec`](https://crates.io/crates/orx-split-vec) and [`Fixed`](https://crates.io/crates/orx-fixed-vec)).
-`PinnedVec` guarantees that elements which are already pushed to the vector stay pinned to their memory locations unless explicitly changed due to removals, which is not the case here since `ConcurrentBag` is a grow-only collection.
-This feature makes it safe to grow with a shared reference on a single thread, as implemented by [`ImpVec`](https://crates.io/crates/orx-imp-vec).
+# Approach and Safety
 
-In order to achieve this feature in a concurrent program, `ConcurrentBag` pairs the `PinnedVec` with an `AtomicUsize`.
-* `len: AtomicSize`: fixes the target memory location of each element to be pushed at the time the `push` method is called. Regardless of whether or not writing to memory completes before another element is pushed, every pushed element receives a unique position reserved for it.
-* `PinnedVec` guarantees that already pushed elements are not moved around in memory during growth. This also enables the following mode of concurrency:
-  * one thread might allocate new memory in order to grow when capacity is reached,
-  * while another thread might concurrently be writing to any of the already allocation memory locations.
+`ConcurrentBag` aims to enable concurrent growth with a minimalistic approach. It requires two major components for this:
+* The underlying storage, which is any `PinnedVec` implementation. This means that memory locations of elements that are already pushed to the vector will never change, unless explicitly changed. This guarantee eliminates a certain set of safety concerns and corresponding complexity.
+* An atomic counter that is responsible for uniquely assigning one vector position to one and only one thread. `std::sync::atomic::AtomicUsize` and its `fetch_add` method are sufficient for this.
 
-The approach guarantees that
-* only one thread can write to the memory location of an element being pushed to the bag,
-* at any point in time, only one thread is responsible for the allocation of memory if the bag requires new memory,
-* no thread reads any of the written elements (reading happens after converting the bag `into_inner`),
-* hence, there exists no race condition.
+Simplicity and safety of the approach can be observed in the implementation of the `push` method.
+
+```rust ignore
+pub fn push(&self, value: T) -> usize {
+    let idx = self.len.fetch_add(1, Ordering::AcqRel);
+    self.assert_has_capacity_for(idx);
+
+    loop {
+        let capacity = self.capacity.load(Ordering::Relaxed);
+
+        match idx.cmp(&capacity) {
+            // no need to grow, just push
+            std::cmp::Ordering::Less => {
+                self.write(idx, value);
+                break;
+            }
+
+            // we are responsible for growth
+            std::cmp::Ordering::Equal => {
+                let new_capacity = self.grow_to(capacity + 1);
+                self.write(idx, value);
+                self.capacity.store(new_capacity, Ordering::Relaxed);
+                break;
+            }
+
+            // spin to wait for responsible thread to handle growth
+            std::cmp::Ordering::Greater => {}
+        }
+    }
+
+    idx
+}
+```
+
+Below are some details about this implementation:
+* `fetch_add` guarantees that each pushed `value` receives a unique idx.
+* `assert_has_capacity_for` method is an additional safety guarantee added to pinned vectors to prevent any possible UB. It is not constraining for practical usage, see [`ConcurrentBag::maximum_capacity`] for details.
+* Inside the loop, we read the current `capacity` and compare it with `idx`:
+  * `idx < capacity`:
+    * The `idx`-th position is already allocated and belongs to the bag. We can simply write. Note that concurrent bag is write-only. Therefore, there is no other thread writing to or reading from this position; and hence, no race condition is present.
+  * `idx > capacity`:
+    * The `idx`-th position is not yet allocated. Underlying pinned vector needs to grow.
+    * But another thread is responsible for the growth, we simply wait.
+  * `idx == capacity`:
+    * The `idx`-th position is not yet allocated. Underlying pinned vector needs to grow.
+    * Further, we are responsible for the growth. Note that this guarantees that:
+      * Only one thread will make the growth calls.
+      * Only one growth call can take place at a given time.
+      * There exists no race condition for the growth.
+    * We first grow the pinned vector, then write to the `idx`-th position, and finally update the `capacity` to the new capacity.
+
+## How many times will we spin?
+
+This is **deterministic**. It is exactly equal to the number of growth calls of the underlying pinned vector, and pinned vector implementations give a detailed control on this. For instance, assume that we will push a total of 15_000 elements concurrently to an empty bag.
+
+* Further assume we use the default `SplitVec<_, Doubling>` as the underlying pinned vector. Throughout the execution, we will allocate fragments of capacities [4, 8, 16, ..., 4096, 8192] which will lead to a total capacity of 16_380. In other words, we might possibly visit the `std::cmp::Ordering::Greater => {}` block in 12 points in time during the entire execution.
+* If we use a `SplitVec<_, Linear>` with constant fragment lengths of 1_024, we will allocate 15 equal capacity fragments, which will lead to a total capacity of 15_360. So looping might only happen 15 times. We can drop this number to 8 if we set constant fragment capacity to 2_048; i.e., we can control the frequency of allocations.
+* If we use the strict `FixedVec<_>`, we have to pre-allocate a safe amount and can never grow beyond this number. Therefore, there will never be any spinning.
+
+## When we spin, how long do we spin?
+
+Not long because:
+* Pinned vectors do not change memory locations of already pushed elements. In other words, growths are copy-free.
+* We are only waiting for allocation of memory required for the growth with respect to the chosen growth strategy.
 
 # Construction
 
-As explained above, `ConcurrentBag` is simply a tuple of a `PinnedVec` and an `AtomicUsize`.
-Therefore, it can be constructed by wrapping any pinned vector; i.e., `ConcurrentBag<T>` implements `From<P: PinnedVec<T>>`.
+`ConcurrentBag` can be constructed by wrapping any pinned vector; i.e., `ConcurrentBag<T>` implements `From<P: PinnedVec<T>>`.
+Likewise, a concurrent vector can be unwrapped without any cost to the underlying pinned vector with `into_inner` method.
+
 Further, there exist `with_` methods to directly construct the concurrent bag with common pinned vector implementations.
 
 ```rust
@@ -115,16 +131,11 @@ let bag: ConcurrentBag<char, SplitVec<char, Doubling>> = ConcurrentBag::with_dou
 let bag: ConcurrentBag<char> = SplitVec::new().into();
 let bag: ConcurrentBag<char, SplitVec<char, Doubling>> = SplitVec::new().into();
 
-// SplitVec with [Recursive](https://docs.rs/orx-split-vec/latest/orx_split_vec/struct.Recursive.html) growth
-let bag: ConcurrentBag<char, SplitVec<char, Recursive>> =
-    ConcurrentBag::with_recursive_growth();
-let bag: ConcurrentBag<char, SplitVec<char, Recursive>> =
-    SplitVec::with_recursive_growth().into();
-
 // SplitVec with [Linear](https://docs.rs/orx-split-vec/latest/orx_split_vec/struct.Linear.html) growth
 // each fragment will have capacity 2^10 = 1024
-let bag: ConcurrentBag<char, SplitVec<char, Linear>> = ConcurrentBag::with_linear_growth(10);
-let bag: ConcurrentBag<char, SplitVec<char, Linear>> = SplitVec::with_linear_growth(10).into();
+// and the split vector can grow up to 32 fragments
+let bag: ConcurrentBag<char, SplitVec<char, Linear>> = ConcurrentBag::with_linear_growth(10, 32);
+let bag: ConcurrentBag<char, SplitVec<char, Linear>> = SplitVec::with_linear_growth_and_fragments_capacity(10, 32).into();
 
 // [FixedVec](https://docs.rs/orx-fixed-vec/latest/orx_fixed_vec/) with fixed capacity.
 // Fixed vector cannot grow; hence, pushing the 1025-th element to this bag will cause a panic!
@@ -143,12 +154,14 @@ let bag: ConcurrentBag<_> = split_vec.into();
 
 # Write-Only vs Read-Write
 
-The concurrent bag is write-only & grow-only bag which is convenient and efficient for collecting elements.
+The concurrent bag is a write-only bag which is convenient and efficient for collecting elements.
 
 See [`ConcurrentVec`](https://crates.io/crates/orx-concurrent-vec) for a read-and-write variant which
+
 * guarantees that reading and writing never happen concurrently, and hence,
-* allows safe iteration or access to already written elements of the concurrent vector,
-* with a minor additional cost of values being wrapped by an `Option`.
+* allows safe iteration or access to already written elements of the concurrent vector.
+
+However, `ConcurrentVec<T>` requires to use a `PinnedVec<Option<T>>` as the underlying storage rather than `PinnedVec<T>`.
 
 <div id="section-benchmarks"></div>
 
@@ -159,3 +172,8 @@ See [`ConcurrentVec`](https://crates.io/crates/orx-concurrent-vec) for a read-an
 In the experiment, `ConcurrentBag` variants and `rayon` is used to collect results from multiple threads. You may see in the table below that `rayon` is extremely fast with very small output data (`i32` in this case). As the output size gets larger and copies become costlier, `ConcurrentBag` starts to perform faster.
 
 <img src="https://raw.githubusercontent.com/orxfun/orx-concurrent-bag/main/docs/img/bench_grow.PNG" alt="https://raw.githubusercontent.com/orxfun/orx-concurrent-bag/main/docs/img/bench_grow.PNG" />
+
+
+## License
+
+This library is licensed under MIT license. See LICENSE for details.

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -2,3 +2,5 @@ pub(crate) const ERR_FAILED_TO_GROW: &str =
     "The underlying pinned vector reached its capacity and failed to grow";
 
 pub(crate) const ERR_FAILED_TO_PUSH: &str = "Failed to push new element to the concurrent bag";
+
+pub(crate) const ERR_REACHED_MAX_CAPACITY: &str = "Out of capacity. Underlying pinned vector cannot grow any further while being concurrently safe.";

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,55 +4,14 @@
 //! [![orx-concurrent-bag documentation](https://docs.rs/orx-concurrent-bag/badge.svg)](https://docs.rs/orx-concurrent-bag)
 //!
 //! An efficient, convenient and lightweight grow-only concurrent collection, ideal for collecting results concurrently.
-//! * **convenient**: the bag can be shared among threads simply as a shared reference, not even requiring `Arc`,
-//! * **efficient**: for collecting results concurrently:
-//!   * rayon is significantly faster when the elements are small and there is an extreme load (no work at all among push calls);
-//!   * `ConcurrentBag` starts to perform faster as elements or the computation in between push calls get larger (see <a href="#section-benchmarks">E. Benchmarks</a> for the experiments).
-//! * **lightweight**: due to the simplistic approach taken, it enables concurrent programs with smaller binary sizes.
 //!
-//! The bag preserves the order of elements with respect to the order the `push` method is called.
+//! * **convenient**: `ConcurrentBag` can safely be shared among threads simply as a shared reference. Further, it is just a wrapper around any [`PinnedVec`](https://crates.io/crates/orx-pinned-vec) implementation adding concurrent safety guarantees. Therefore, underlying pinned vector and concurrent bag can be converted to each other back and forth without any cost.
+//! * **lightweight**: This crate takes a simplistic approach built on pinned vector guarantees which leads to concurrent programs with few dependencies and small binaries (see <a href="#section-approach-and-safety">approach and safety</a> for details).
+//! * **efficient**: `ConcurrentBag` is a lock free structure making use of a few atomic primitives. rayon is significantly faster when collecting small results under an extreme load (negligible work to compute results); however, `ConcurrentBag` starts to perform faster as result types get larger (see <a href="#section-benchmarks">benchmarks</a> for the experiments).
 //!
 //! # Examples
 //!
-//! Safety guarantees to push to the bag with an immutable reference makes it easy to share the bag among threads.
-//!
-//! ## Using `std::sync::Arc`
-//!
-//! We can share our bag among threads using `Arc` and collect results concurrently.
-//!
-//! ```rust
-//! use orx_concurrent_bag::*;
-//! use std::{sync::Arc, thread};
-//!
-//! let (num_threads, num_items_per_thread) = (4, 8);
-//!
-//! let bag = Arc::new(ConcurrentBag::new());
-//! let mut thread_vec: Vec<thread::JoinHandle<()>> = Vec::new();
-//!
-//! for i in 0..num_threads {
-//!     let bag = bag.clone();
-//!     thread_vec.push(thread::spawn(move || {
-//!         for j in 0..num_items_per_thread {
-//!             // concurrently collect results simply by calling `push`
-//!             bag.push(i * 1000 + j);
-//!         }
-//!     }));
-//! }
-//!
-//! for handle in thread_vec {
-//!     handle.join().unwrap();
-//! }
-//!
-//! let mut vec_from_bag: Vec<_> = unsafe { bag.iter() }.copied().collect();
-//! vec_from_bag.sort();
-//! let mut expected: Vec<_> = (0..num_threads).flat_map(|i| (0..num_items_per_thread).map(move |j| i * 1000 + j)).collect();
-//! expected.sort();
-//! assert_eq!(vec_from_bag, expected);
-//! ```
-//!
-//! ## Using `std::thread::scope`
-//!
-//! An even more convenient approach would be to use thread scopes. This allows to use shared reference of the bag across threads, instead of `Arc`.
+//! Safety guarantees to push to the bag with an immutable reference makes it easy to share the bag among threads. `std::sync::Arc` can be used; however, it is not required as demonstrated below.
 //!
 //! ```rust
 //! use orx_concurrent_bag::*;
@@ -60,7 +19,8 @@
 //! let (num_threads, num_items_per_thread) = (4, 8);
 //!
 //! let bag = ConcurrentBag::new();
-//! let bag_ref = &bag; // just take a reference
+//! let bag_ref = &bag; // just take a reference and share among threads
+//!
 //! std::thread::scope(|s| {
 //!     for i in 0..num_threads {
 //!         s.spawn(move || {
@@ -79,28 +39,84 @@
 //! assert_eq!(vec_from_bag, expected);
 //! ```
 //!
-//! # Safety
+//! <div id="section-approach-and-safety"></div>
 //!
-//! `ConcurrentBag` uses a [`PinnedVec`](https://crates.io/crates/orx-pinned-vec) implementation as the underlying storage (see [`SplitVec`](https://crates.io/crates/orx-split-vec) and [`Fixed`](https://crates.io/crates/orx-fixed-vec)).
-//! `PinnedVec` guarantees that elements which are already pushed to the vector stay pinned to their memory locations unless explicitly changed due to removals, which is not the case here since `ConcurrentBag` is a grow-only collection.
-//! This feature makes it safe to grow with a shared reference on a single thread, as implemented by [`ImpVec`](https://crates.io/crates/orx-imp-vec).
+//! # Approach and Safety
 //!
-//! In order to achieve this feature in a concurrent program, `ConcurrentBag` pairs the `PinnedVec` with an `AtomicUsize`.
-//! * `len: AtomicSize`: fixes the target memory location of each element to be pushed at the time the `push` method is called. Regardless of whether or not writing to memory completes before another element is pushed, every pushed element receives a unique position reserved for it.
-//! * `PinnedVec` guarantees that already pushed elements are not moved around in memory during growth. This also enables the following mode of concurrency:
-//!   * one thread might allocate new memory in order to grow when capacity is reached,
-//!   * while another thread might concurrently be writing to any of the already allocation memory locations.
+//! `ConcurrentBag` aims to enable concurrent growth with a minimalistic approach. It requires two major components for this:
+//! * The underlying storage, which is any `PinnedVec` implementation. This means that memory locations of elements that are already pushed to the vector will never change, unless explicitly changed. This guarantee eliminates a certain set of safety concerns and corresponding complexity.
+//! * An atomic counter that is responsible for uniquely assigning one vector position to one and only one thread. `std::sync::atomic::AtomicUsize` and its `fetch_add` method are sufficient for this.
 //!
-//! The approach guarantees that
-//! * only one thread can write to the memory location of an element being pushed to the bag,
-//! * at any point in time, only one thread is responsible for the allocation of memory if the bag requires new memory,
-//! * no thread reads any of the written elements (reading happens after converting the bag `into_inner`),
-//! * hence, there exists no race condition.
+//! Simplicity and safety of the approach can be observed in the implementation of the `push` method.
+//!
+//! ```rust ignore
+//! pub fn push(&self, value: T) -> usize {
+//!     let idx = self.len.fetch_add(1, Ordering::AcqRel);
+//!     self.assert_has_capacity_for(idx);
+//!
+//!     loop {
+//!         let capacity = self.capacity.load(Ordering::Relaxed);
+//!
+//!         match idx.cmp(&capacity) {
+//!             // no need to grow, just push
+//!             std::cmp::Ordering::Less => {
+//!                 self.write(idx, value);
+//!                 break;
+//!             }
+//!
+//!             // we are responsible for growth
+//!             std::cmp::Ordering::Equal => {
+//!                 let new_capacity = self.grow_to(capacity + 1);
+//!                 self.write(idx, value);
+//!                 self.capacity.store(new_capacity, Ordering::Relaxed);
+//!                 break;
+//!             }
+//!
+//!             // spin to wait for responsible thread to handle growth
+//!             std::cmp::Ordering::Greater => {}
+//!         }
+//!     }
+//!
+//!     idx
+//! }
+//! ```
+//!
+//! Below are some details about this implementation:
+//! * `fetch_add` guarantees that each pushed `value` receives a unique idx.
+//! * `assert_has_capacity_for` method is an additional safety guarantee added to pinned vectors to prevent any possible UB. It is not constraining for practical usage, see [`ConcurrentBag::maximum_capacity`] for details.
+//! * Inside the loop, we read the current `capacity` and compare it with `idx`:
+//!   * `idx < capacity`:
+//!     * The `idx`-th position is already allocated and belongs to the bag. We can simply write. Note that concurrent bag is write-only. Therefore, there is no other thread writing to or reading from this position; and hence, no race condition is present.
+//!   * `idx > capacity`:
+//!     * The `idx`-th position is not yet allocated. Underlying pinned vector needs to grow.
+//!     * But another thread is responsible for the growth, we simply wait.
+//!   * `idx == capacity`:
+//!     * The `idx`-th position is not yet allocated. Underlying pinned vector needs to grow.
+//!     * Further, we are responsible for the growth. Note that this guarantees that:
+//!       * Only one thread will make the growth calls.
+//!       * Only one growth call can take place at a given time.
+//!       * There exists no race condition for the growth.
+//!     * We first grow the pinned vector, then write to the `idx`-th position, and finally update the `capacity` to the new capacity.
+//!
+//! ## How many times will we spin?
+//!
+//! This is **deterministic**. It is exactly equal to the number of growth calls of the underlying pinned vector, and pinned vector implementations give a detailed control on this. For instance, assume that we will push a total of 15_000 elements concurrently to an empty bag.
+//!
+//! * Further assume we use the default `SplitVec<_, Doubling>` as the underlying pinned vector. Throughout the execution, we will allocate fragments of capacities [4, 8, 16, ..., 4096, 8192] which will lead to a total capacity of 16_380. In other words, we might possibly visit the `std::cmp::Ordering::Greater => {}` block in 12 points in time during the entire execution.
+//! * If we use a `SplitVec<_, Linear>` with constant fragment lengths of 1_024, we will allocate 15 equal capacity fragments, which will lead to a total capacity of 15_360. So looping might only happen 15 times. We can drop this number to 8 if we set constant fragment capacity to 2_048; i.e., we can control the frequency of allocations.
+//! * If we use the strict `FixedVec<_>`, we have to pre-allocate a safe amount and can never grow beyond this number. Therefore, there will never be any spinning.
+//!
+//! ## When we spin, how long do we spin?
+//!
+//! Not long because:
+//! * Pinned vectors do not change memory locations of already pushed elements. In other words, growths are copy-free.
+//! * We are only waiting for allocation of memory required for the growth with respect to the chosen growth strategy.
 //!
 //! # Construction
 //!
-//! As explained above, `ConcurrentBag` is simply a tuple of a `PinnedVec` and an `AtomicUsize`.
-//! Therefore, it can be constructed by wrapping any pinned vector; i.e., `ConcurrentBag<T>` implements `From<P: PinnedVec<T>>`.
+//! `ConcurrentBag` can be constructed by wrapping any pinned vector; i.e., `ConcurrentBag<T>` implements `From<P: PinnedVec<T>>`.
+//! Likewise, a concurrent vector can be unwrapped without any cost to the underlying pinned vector with `into_inner` method.
+//!
 //! Further, there exist `with_` methods to directly construct the concurrent bag with common pinned vector implementations.
 //!
 //! ```rust
@@ -115,16 +131,11 @@
 //! let bag: ConcurrentBag<char> = SplitVec::new().into();
 //! let bag: ConcurrentBag<char, SplitVec<char, Doubling>> = SplitVec::new().into();
 //!
-//! // SplitVec with [Recursive](https://docs.rs/orx-split-vec/latest/orx_split_vec/struct.Recursive.html) growth
-//! let bag: ConcurrentBag<char, SplitVec<char, Recursive>> =
-//!     ConcurrentBag::with_recursive_growth();
-//! let bag: ConcurrentBag<char, SplitVec<char, Recursive>> =
-//!     SplitVec::with_recursive_growth().into();
-//!
 //! // SplitVec with [Linear](https://docs.rs/orx-split-vec/latest/orx_split_vec/struct.Linear.html) growth
 //! // each fragment will have capacity 2^10 = 1024
-//! let bag: ConcurrentBag<char, SplitVec<char, Linear>> = ConcurrentBag::with_linear_growth(10);
-//! let bag: ConcurrentBag<char, SplitVec<char, Linear>> = SplitVec::with_linear_growth(10).into();
+//! // and the split vector can grow up to 32 fragments
+//! let bag: ConcurrentBag<char, SplitVec<char, Linear>> = ConcurrentBag::with_linear_growth(10, 32);
+//! let bag: ConcurrentBag<char, SplitVec<char, Linear>> = SplitVec::with_linear_growth_and_fragments_capacity(10, 32).into();
 //!
 //! // [FixedVec](https://docs.rs/orx-fixed-vec/latest/orx_fixed_vec/) with fixed capacity.
 //! // Fixed vector cannot grow; hence, pushing the 1025-th element to this bag will cause a panic!
@@ -143,12 +154,14 @@
 //!
 //! # Write-Only vs Read-Write
 //!
-//! The concurrent bag is write-only & grow-only bag which is convenient and efficient for collecting elements.
+//! The concurrent bag is a write-only bag which is convenient and efficient for collecting elements.
 //!
 //! See [`ConcurrentVec`](https://crates.io/crates/orx-concurrent-vec) for a read-and-write variant which
+//!
 //! * guarantees that reading and writing never happen concurrently, and hence,
-//! * allows safe iteration or access to already written elements of the concurrent vector,
-//! * with a minor additional cost of values being wrapped by an `Option`.
+//! * allows safe iteration or access to already written elements of the concurrent vector.
+//!
+//! However, `ConcurrentVec<T>` requires to use a `PinnedVec<Option<T>>` as the underlying storage rather than `PinnedVec<T>`.
 //!
 //! <div id="section-benchmarks"></div>
 //!
@@ -159,6 +172,11 @@
 //! In the experiment, `ConcurrentBag` variants and `rayon` is used to collect results from multiple threads. You may see in the table below that `rayon` is extremely fast with very small output data (`i32` in this case). As the output size gets larger and copies become costlier, `ConcurrentBag` starts to perform faster.
 //!
 //! <img src="https://raw.githubusercontent.com/orxfun/orx-concurrent-bag/main/docs/img/bench_grow.PNG" alt="https://raw.githubusercontent.com/orxfun/orx-concurrent-bag/main/docs/img/bench_grow.PNG" />
+//!
+//!
+//! ## License
+//!
+//! This library is licensed under MIT license. See LICENSE for details.
 
 #![warn(
     missing_docs,
@@ -176,7 +194,10 @@ mod bag;
 mod common_traits;
 mod errors;
 
+/// Common relevant traits, structs, enums.
+pub mod prelude;
+
 pub use bag::ConcurrentBag;
 pub use orx_fixed_vec::FixedVec;
-pub use orx_pinned_vec::PinnedVec;
+pub use orx_pinned_vec::{CapacityState, PinnedVec, PinnedVecGrowthError};
 pub use orx_split_vec::{Doubling, Linear, Recursive, SplitVec};

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -1,0 +1,4 @@
+pub use crate::bag::ConcurrentBag;
+pub use orx_fixed_vec::FixedVec;
+pub use orx_pinned_vec::{CapacityState, PinnedVec, PinnedVecGrowthError};
+pub use orx_split_vec::{Doubling, Linear, Recursive, SplitVec};

--- a/tests/push.rs
+++ b/tests/push.rs
@@ -5,7 +5,7 @@ use orx_split_vec::SplitVec;
 use std::{sync::Arc, thread, time::Duration};
 use test_case::test_case;
 
-const NUM_RERUNS: usize = 16;
+const NUM_RERUNS: usize = 64;
 
 const EXHAUSTIVE_INPUTS: [(usize, usize); 14] = [
     (1, 64),
@@ -99,23 +99,21 @@ fn run_test<P: PinnedVec<i32> + Clone + 'static>(pinned: P, inputs: &[(usize, us
 }
 
 #[test_case(FixedVec::new(524288))]
-#[test_case(SplitVec::new())]
-#[test_case(SplitVec::with_doubling_growth())]
-#[test_case(SplitVec::with_recursive_growth())]
-#[test_case(SplitVec::with_linear_growth(6))]
-#[test_case(SplitVec::with_linear_growth(10))]
-#[test_case(SplitVec::with_linear_growth(14))]
+#[test_case(SplitVec::with_doubling_growth_and_fragments_capacity(32))]
+#[test_case(SplitVec::with_recursive_growth_and_fragments_capacity(32))]
+#[test_case(SplitVec::with_linear_growth_and_fragments_capacity(6, 8192))]
+#[test_case(SplitVec::with_linear_growth_and_fragments_capacity(10, 512))]
+#[test_case(SplitVec::with_linear_growth_and_fragments_capacity(14, 32))]
 fn exhaustive<P: PinnedVec<i32> + Clone + 'static>(pinned: P) {
     run_test(pinned, &EXHAUSTIVE_INPUTS)
 }
 
 #[test_case(FixedVec::new(3000))]
-#[test_case(SplitVec::new())]
-#[test_case(SplitVec::with_doubling_growth())]
-#[test_case(SplitVec::with_recursive_growth())]
-#[test_case(SplitVec::with_linear_growth(6))]
-#[test_case(SplitVec::with_linear_growth(10))]
-#[test_case(SplitVec::with_linear_growth(14))]
+#[test_case(SplitVec::with_doubling_growth_and_fragments_capacity(32))]
+#[test_case(SplitVec::with_recursive_growth_and_fragments_capacity(32))]
+#[test_case(SplitVec::with_linear_growth_and_fragments_capacity(6, 40))]
+#[test_case(SplitVec::with_linear_growth_and_fragments_capacity(10, 10))]
+#[test_case(SplitVec::with_linear_growth_and_fragments_capacity(14, 10))]
 fn fast<P: PinnedVec<i32> + Clone + 'static>(pinned: P) {
     run_test(pinned, &FAST_INPUTS)
 }

--- a/tests/push_out_of_capacity.rs
+++ b/tests/push_out_of_capacity.rs
@@ -1,0 +1,72 @@
+use orx_concurrent_bag::*;
+use orx_fixed_vec::FixedVec;
+use orx_pinned_vec::PinnedVec;
+use orx_split_vec::SplitVec;
+use std::time::Duration;
+
+fn run_with_scope<P: PinnedVec<i32> + Clone + 'static>(
+    pinned: P,
+    num_threads: usize,
+    num_items_per_thread: usize,
+    do_sleep: bool,
+) {
+    let bag: ConcurrentBag<_, _> = pinned.clone().into();
+    let bag_ref = &bag;
+    std::thread::scope(|s| {
+        for i in 0..num_threads {
+            s.spawn(move || {
+                sleep(do_sleep, i);
+                for j in 0..num_items_per_thread {
+                    bag_ref.push((i * 100000 + j) as i32);
+                }
+            });
+        }
+    });
+}
+
+#[test]
+#[should_panic]
+fn out_of_capacity_linear() {
+    let (num_threads, num_items_per_thread) = (4, 1024);
+    let pinned = SplitVec::with_linear_growth_and_fragments_capacity(5, 10); // up to 320
+    run_with_scope(pinned, num_threads, num_items_per_thread, true);
+}
+
+#[test]
+#[should_panic]
+fn out_of_capacity_doubling() {
+    let (num_threads, num_items_per_thread) = (5, 15);
+    let pinned = SplitVec::with_doubling_growth_and_fragments_capacity(4); // up to 4 + 8 + 16 + 32 = 60
+    run_with_scope(pinned, num_threads, num_items_per_thread, true);
+}
+
+#[test]
+#[should_panic]
+fn out_of_capacity_recursive() {
+    let (num_threads, num_items_per_thread) = (5, 15);
+    let pinned = SplitVec::with_recursive_growth_and_fragments_capacity(4); // up to 4 + 8 + 16 + 32 = 60
+    run_with_scope(pinned, num_threads, num_items_per_thread, true);
+}
+
+#[test]
+#[should_panic]
+fn out_of_capacity_fixed() {
+    let (num_threads, num_items_per_thread) = (5, 15);
+    let pinned = FixedVec::new(74);
+    run_with_scope(pinned, num_threads, num_items_per_thread, true);
+}
+
+// helpers
+
+fn sleep(do_sleep: bool, i: usize) {
+    if do_sleep {
+        let modulus = i % 3;
+        let milliseconds = match modulus {
+            0 => 0,
+            1 => 10 + (i % 11) * 4,
+            _ => 20 - (i % 5) * 3,
+        } as u64;
+        let duration = Duration::from_millis(milliseconds);
+        std::thread::sleep(duration);
+    }
+}


### PR DESCRIPTION
* Updating to the new `PinnedVec` and consecutively `SplitVec` and `FixedVec` releases which provide additional support for safety of concurrent programs.
* Constructors are revised:
  * `with_doubling_growth` reserves for 32 fragments. With the doubling growth strategy, this allows for a practically sufficient maximum capacity.
  * `with_linear_growth` now requires `fragment_capacity` as the second argument, giving the caller complete control of setting the maximum capacity.
* `reserve_maximum_capacity` method is implemented. This method allows to increase maximum capacity; however, with a mutually exclusive reference. And hence, safely without any race conditions.
* `maximum_capacity` method is implemented to provide access to this upper bound.
* `push` method is revised and simplified. Its documentation is updated, Panics section is added pointing to the maximum_capacity safety guarantee.
* Test coverage is increased.
* Major revision on documentation.