### PR TITLE
`FillStrategy` trait to provide safety in read&write situations

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "orx-concurrent-bag"
-version = "1.7.0"
+version = "1.8.0"
 edition = "2021"
 authors = ["orxfun <orx.ugur.arikan@gmail.com>"]
 description = "An efficient, convenient and lightweight grow-only concurrent collection."

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ An efficient, convenient and lightweight grow-only concurrent collection.
 
 * **convenient**: `ConcurrentBag` can safely be shared among threads simply as a shared reference. Further, it is just a wrapper around any [`PinnedVec`](https://crates.io/crates/orx-pinned-vec) implementation adding concurrent safety guarantees. Therefore, underlying pinned vector and concurrent bag can be converted to each other back and forth without any cost (see <a href="#section-construction-and-conversions">construction and conversions</a>).
 * **lightweight**: This crate takes a simplistic approach built on pinned vector guarantees which leads to concurrent programs with few dependencies and small binaries (see <a href="#section-approach-and-safety">approach and safety</a> for details).
-* **efficient**: `ConcurrentBag` is a lock free structure making use of a few atomic primitives. We can see in experiments explained in <a href="#section-benchmarks">benchmarks</a> that it can outperform rayon's convenient parallel iterator due to its do-less and copy-free approach.
+* **efficient**: `ConcurrentBag` is a lock free structure making use of a few atomic primitives, this leads to high performance growth. You may see the details in <a href="#section-benchmarks">benchmarks</a> and further <a href="#section-performance-notes">performance notes</a>.
 
 # A. Examples
 
@@ -243,7 +243,7 @@ Another common approach to deal with false sharing is to add padding (unused byt
 
 <div id="section-construction-and-conversions"></div>
 
-# E. Construction and Conversions (from / into_inner)
+# E. `From` | `Into` | `into_inner`
 
 `ConcurrentBag` can be constructed by wrapping any pinned vector; i.e., `ConcurrentBag<T>` implements `From<P: PinnedVec<T>>`.
 Likewise, a concurrent vector can be unwrapped without any cost to the underlying pinned vector with `into_inner` method.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,7 +7,7 @@
 //!
 //! * **convenient**: `ConcurrentBag` can safely be shared among threads simply as a shared reference. Further, it is just a wrapper around any [`PinnedVec`](https://crates.io/crates/orx-pinned-vec) implementation adding concurrent safety guarantees. Therefore, underlying pinned vector and concurrent bag can be converted to each other back and forth without any cost (see <a href="#section-construction-and-conversions">construction and conversions</a>).
 //! * **lightweight**: This crate takes a simplistic approach built on pinned vector guarantees which leads to concurrent programs with few dependencies and small binaries (see <a href="#section-approach-and-safety">approach and safety</a> for details).
-//! * **efficient**: `ConcurrentBag` is a lock free structure making use of a few atomic primitives. We can see in experiments explained in <a href="#section-benchmarks">benchmarks</a> that it can outperform rayon's convenient parallel iterator due to its do-less and copy-free approach.
+//! * **efficient**: `ConcurrentBag` is a lock free structure making use of a few atomic primitives, this leads to high performance growth. You may see the details in <a href="#section-benchmarks">benchmarks</a> and further <a href="#section-performance-notes">performance notes</a>.
 //!
 //! # A. Examples
 //!
@@ -34,11 +34,10 @@
 //!     }
 //! });
 //!
-//! let mut vec_from_bag: Vec<_> = bag.into_inner().iter().copied().collect();
-//! vec_from_bag.sort();
-//! let mut expected: Vec<_> = (0..num_threads).flat_map(|i| (0..num_items_per_thread).map(move |j| i * 1000 + j)).collect();
-//! expected.sort();
-//! assert_eq!(vec_from_bag, expected);
+//! assert_eq!(bag.len(), num_threads * num_items_per_thread);
+//!
+//! let pinned_vec = bag.into_inner();
+//! assert_eq!(pinned_vec.len(), num_threads * num_items_per_thread);
 //! ```
 //!
 //! <div id="section-approach-and-safety"></div>
@@ -211,10 +210,7 @@
 //! use orx_concurrent_bag::*;
 //!
 //! let (num_threads, num_items_per_thread) = (4, 1_024);
-//!
 //! let bag = ConcurrentBag::new();
-//!
-//! // just take a reference and share among threads
 //! let bag_ref = &bag;
 //! let batch_size = 16;
 //!
@@ -223,18 +219,11 @@
 //!         s.spawn(move || {
 //!             for j in (0..num_items_per_thread).step_by(batch_size) {
 //!                 let iter = (j..(j + batch_size)).map(|j| i * 1000 + j);
-//!                 // concurrently collect results simply by calling `extend`
 //!                 bag_ref.extend(iter);
 //!             }
 //!         });
 //!     }
 //! });
-//!
-//! let mut vec_from_bag: Vec<_> = bag.into_inner().iter().copied().collect();
-//! vec_from_bag.sort();
-//! let mut expected: Vec<_> = (0..num_threads).flat_map(|i| (0..num_items_per_thread).map(move |j| i * 1000 + j)).collect();
-//! expected.sort();
-//! assert_eq!(vec_from_bag, expected);
 //! ```
 //!
 //! ### Solution-II: Padding
@@ -243,7 +232,7 @@
 //!
 //! <div id="section-construction-and-conversions"></div>
 //!
-//! # E. Construction and Conversions (from / into_inner)
+//! # E. `From` | `Into` | `into_inner`
 //!
 //! `ConcurrentBag` can be constructed by wrapping any pinned vector; i.e., `ConcurrentBag<T>` implements `From<P: PinnedVec<T>>`.
 //! Likewise, a concurrent vector can be unwrapped without any cost to the underlying pinned vector with `into_inner` method.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -314,11 +314,13 @@
 mod bag;
 mod common_traits;
 mod errors;
+mod mem_fill;
 
 /// Common relevant traits, structs, enums.
 pub mod prelude;
 
 pub use bag::ConcurrentBag;
+pub use mem_fill::{EagerWithDefault, FillStrategy, Lazy};
 pub use orx_fixed_vec::FixedVec;
 pub use orx_pinned_vec::{CapacityState, PinnedVec, PinnedVecGrowthError};
 pub use orx_split_vec::{Doubling, Linear, Recursive, SplitVec};

--- a/src/mem_fill.rs
+++ b/src/mem_fill.rs
@@ -1,0 +1,138 @@
+use crate::ConcurrentBag;
+use orx_fixed_vec::PinnedVec;
+
+mod sealed {
+    pub trait FillStrategy {}
+}
+
+/// Strategy defining how out-of-bounds positions of the concurrent bag will be filled.
+pub trait FillStrategy<T, P>: sealed::FillStrategy
+where
+    P: PinnedVec<T>,
+{
+    /// Fills the `bag` positions between `begin_idx` and `new_capacity` with the defined strategy.
+    fn fill_new_memory(bag: &ConcurrentBag<T, P>, begin_idx: usize, new_capacity: usize);
+}
+
+/// Lazy strategy does not fill the positions between `len()` and `capacity`.
+/// Note that this is perfectly safe for `ConcurrentBag`.
+///
+/// However, if the caller decides to use the unsafe read methods such as `get` and `iter`,
+/// using `EagerWithDefault` completely prevents the possibility of an undefined behavior due to reading an uninitialized memory.
+pub struct Lazy;
+
+impl sealed::FillStrategy for Lazy {}
+
+impl<T, P: PinnedVec<T>> FillStrategy<T, P> for Lazy {
+    fn fill_new_memory(_: &ConcurrentBag<T, P>, _: usize, _: usize) {}
+}
+
+// default
+/// EagerWithDefault strategy fills the positions between `len()` and `capacity` with the default value of the element type.
+/// Note that this is an additional safety guarantee which is required only if unsafe read methods of the `ConcurrentBag, such as `get` and `iter`, are to be used.
+///
+/// Filling with defaults completely prevents the possibility of an undefined behavior due to reading an uninitialized memory.
+///
+/// As expected, the tradeoff is initialization of allocation memory before pushing the elements to it.
+pub struct EagerWithDefault;
+
+impl sealed::FillStrategy for EagerWithDefault {}
+
+impl<T: Default, P: PinnedVec<T>> FillStrategy<T, P> for EagerWithDefault {
+    fn fill_new_memory(bag: &ConcurrentBag<T, P>, begin_idx: usize, new_capacity: usize) {
+        for i in begin_idx..new_capacity {
+            bag.write(i, T::default());
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use test_case::test_case;
+
+    fn validate<P: PinnedVec<char>>(bag: ConcurrentBag<char, P>) {
+        assert!(bag.capacity() > 4);
+
+        unsafe {
+            assert_eq!(bag.get(4), Some(&'x'));
+
+            for i in 5..bag.capacity() + 10 {
+                assert_eq!(bag.get(i), None);
+            }
+        }
+
+        let mut pinned = bag.into_inner();
+        assert_eq!(5, pinned.len());
+        assert!(pinned.capacity() > 4);
+
+        unsafe {
+            let ptr = pinned.get_ptr_mut(4).expect("in-capacity");
+            assert_eq!(*ptr, 'x');
+
+            for i in 5..pinned.capacity() {
+                let ptr = pinned.get_ptr_mut(i).expect("in-capacity");
+                assert_eq!(*ptr, char::default());
+            }
+
+            for i in pinned.capacity()..(pinned.capacity() + 10) {
+                let ptr = pinned.get_ptr_mut(i);
+                assert_eq!(ptr, None);
+            }
+        }
+    }
+
+    #[test_case(ConcurrentBag::with_linear_growth(2, 64))]
+    #[test_case(ConcurrentBag::with_doubling_growth())]
+    fn eager_push_and_fill<P: PinnedVec<char>>(bag: ConcurrentBag<char, P>) {
+        bag.push_and_fill::<EagerWithDefault>('a');
+        bag.push_and_fill::<EagerWithDefault>('b');
+        bag.push_and_fill::<EagerWithDefault>('c');
+        bag.push_and_fill::<EagerWithDefault>('d');
+
+        assert_eq!(4, bag.capacity());
+
+        let pinned = bag.into_inner();
+        assert_eq!(
+            pinned.iter().copied().collect::<Vec<_>>(),
+            ['a', 'b', 'c', 'd']
+        );
+
+        let bag: ConcurrentBag<_, _> = pinned.into();
+        bag.push_and_fill::<EagerWithDefault>('x');
+
+        validate(bag);
+    }
+
+    #[test_case(ConcurrentBag::with_linear_growth(2, 64))]
+    #[test_case(ConcurrentBag::with_doubling_growth())]
+    fn eager_extend_and_fill<P: PinnedVec<char>>(bag: ConcurrentBag<char, P>) {
+        bag.extend_and_fill::<_, _, EagerWithDefault>(['a', 'b', 'c']);
+
+        assert_eq!(4, bag.capacity());
+
+        let pinned = bag.into_inner();
+        assert_eq!(pinned.iter().copied().collect::<Vec<_>>(), ['a', 'b', 'c']);
+
+        let bag: ConcurrentBag<_, _> = pinned.into();
+        bag.extend_and_fill::<_, _, EagerWithDefault>(['d', 'x']);
+
+        validate(bag);
+    }
+
+    #[test_case(ConcurrentBag::with_linear_growth(2, 64))]
+    #[test_case(ConcurrentBag::with_doubling_growth())]
+    fn eager_extend_n_items_and_fill<P: PinnedVec<char>>(bag: ConcurrentBag<char, P>) {
+        unsafe { bag.extend_n_items_and_fill::<_, EagerWithDefault>(['a', 'b', 'c'], 3) };
+
+        assert_eq!(4, bag.capacity());
+
+        let pinned = bag.into_inner();
+        assert_eq!(pinned.iter().copied().collect::<Vec<_>>(), ['a', 'b', 'c']);
+
+        let bag: ConcurrentBag<_, _> = pinned.into();
+        unsafe { bag.extend_n_items_and_fill::<_, EagerWithDefault>(['d', 'x'], 2) };
+
+        validate(bag);
+    }
+}


### PR DESCRIPTION
* unsafe `get` method is implemented.
* `FillStrategy` trait is defined. This is a sealed trait with two implementations: `Lazy` and `EagerWithDefault`. `Lazy` is the default implementation used in the concurrent bag which complies with the safety guarantees and avoids unnecessary work of initializing out-of-bounds memory. On the other hand, if the caller decides to use the unsafe read methods such as `get` or `iter`, then, adding items to the bag using `EagerWithDefault` would guarantee that we do not observe the undefined behavior of reading uninitialized memory. This has a cost; however, it would not necessarily have a significant performance impact.
* `push_and_fill`, `extend_and_fill` and `extend_n_items_and_fill` methods are implemented. These methods are the generic variants which additionally take the generic argument `FillStrategy`.
* Tests are extended.