### PR TITLE
PinnedConcurrentCol migration

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "orx-concurrent-bag"
-version = "1.10.0"
+version = "1.11.0"
 edition = "2021"
 authors = ["orxfun <orx.ugur.arikan@gmail.com>"]
 description = "An efficient, convenient and lightweight grow-only concurrent data structure allowing high performance concurrent collection."
@@ -10,9 +10,10 @@ keywords = ["concurrency", "bag", "data-structures", "atomic", "lock-free"]
 categories = ["data-structures", "concurrency", "rust-patterns"]
 
 [dependencies]
-orx-fixed-vec = "2.7"
-orx-pinned-vec = "2.7"
-orx-split-vec = "2.8"
+orx-fixed-vec = "2.8"
+orx-pinned-concurrent-col = "1.0"
+orx-pinned-vec = "2.8"
+orx-split-vec = "2.9"
 
 [dev-dependencies]
 criterion = "0.5.1"

--- a/README.md
+++ b/README.md
@@ -5,17 +5,16 @@
 
 An efficient, convenient and lightweight grow-only concurrent data structure allowing high performance concurrent collection.
 
-* **convenient**: `ConcurrentBag` can safely be shared among threads simply as a shared reference. Further, it is just a wrapper around any [`PinnedVec`](https://crates.io/crates/orx-pinned-vec) implementation adding concurrent safety guarantees. Therefore, underlying pinned vector and concurrent bag can be converted to each other back and forth without any cost (see <a href="#section-construction-and-conversions">construction and conversions</a>).
-* **lightweight**: This crate takes a simplistic approach built on pinned vector guarantees which leads to concurrent programs with few dependencies and small binaries (see <a href="#section-approach-and-safety">approach and safety</a> for details).
-* **efficient**: `ConcurrentBag` is a lock free structure making use of atomic primitives, this leads to high performance growth. You may see the details in <a href="#section-benchmarks">benchmarks</a> and further <a href="#section-performance-notes">performance notes</a>.
+* **convenient**: `ConcurrentBag` can safely be shared among threads simply as a shared reference. It is a [`PinnedConcurrentCol`](https://crates.io/crates/orx-pinned-concurrent-col) with a special concurrent state implementation. Underlying [`PinnedVec`](https://crates.io/crates/orx-pinned-vec) and concurrent bag can be converted back and forth to each other.
+* **efficient**: `ConcurrentBag` is a lock free structure making use of a few atomic primitives, this leads to high performance concurrent growth. You may see the details in <a href="#section-benchmarks">benchmarks</a> and further <a href="#section-performance-notes">performance notes</a>.
 
-Note that `ConcurrentBag` is a **write only** collection which is optimized for high performance concurrent collection. When we need to safely read elements while the collection concurrently grows, [`ConcurrentVec`](https://crates.io/crates/orx-concurrent-vec) is preferable due to its additional safety guarantees. Having almost identical api, switching between `ConcurrentBag` and `ConcurrentVec` is straightforward.
+Note that `ConcurrentBag` is write only (with the safe api), see [`ConcurrentVec`](https://crates.io/crates/orx-concurrent-vec) for a read & write variant.
 
-# A. Examples
+# Examples
 
 Safety guarantees to push to the bag with a shared reference makes it easy to share the bag among threads. `std::sync::Arc` can be used; however, it is not required as demonstrated below.
 
-```rust
+ ```rust
 use orx_concurrent_bag::*;
 
 let (num_threads, num_items_per_thread) = (4, 1_024);
@@ -23,87 +22,79 @@ let (num_threads, num_items_per_thread) = (4, 1_024);
 let bag = ConcurrentBag::new();
 
 // just take a reference and share among threads
-let bag_ref = &bag;
+let con_bag = &bag;
 
 std::thread::scope(|s| {
     for i in 0..num_threads {
         s.spawn(move || {
             for j in 0..num_items_per_thread {
                 // concurrently collect results simply by calling `push`
-                bag_ref.push(i * 1000 + j);
+                con_bag.push(i * 1000 + j);
             }
         });
     }
 });
 
-assert_eq!(bag.len(), num_threads * num_items_per_thread);
-
-let pinned_vec = bag.into_inner();
-assert_eq!(pinned_vec.len(), num_threads * num_items_per_thread);
+let mut vec_from_bag: Vec<_> = bag.into_inner().iter().copied().collect();
+vec_from_bag.sort();
+let mut expected: Vec<_> = (0..num_threads).flat_map(|i| (0..num_items_per_thread).map(move |j| i * 1000 + j)).collect();
+expected.sort();
+assert_eq!(vec_from_bag, expected);
 ```
 
-<div id="section-approach-and-safety"></div>
+### Construction
 
-# B. Approach and Safety
+`ConcurrentBag` can be constructed by wrapping any pinned vector; i.e., `ConcurrentBag<T>` implements `From<P: PinnedVec<T>>`. Likewise, a concurrent vector can be unwrapped without any allocation to the underlying pinned vector with `into_inner` method.
 
-`ConcurrentBag` aims to enable concurrent growth with a minimalistic approach. It requires two major components for this:
-* The underlying storage, which is any `PinnedVec` implementation. Pinned vectors guarantee that memory locations of its elements will never change, unless explicitly changed. This guarantee eliminates a certain set of safety concerns and corresponding complexity.
-* An atomic counter that is responsible for uniquely assigning one vector position to one and only one thread. `std::sync::atomic::AtomicUsize` and its `fetch_add` method are sufficient for this.
+Further, there exist `with_` methods to directly construct the concurrent bag with common pinned vector implementations.
 
-Simplicity and safety of the approach can be observed in the implementation of the `push` method.
+```rust
+use orx_concurrent_bag::*;
 
-```rust ignore
-pub fn push(&self, value: T) -> usize {
-    let idx = self.len.fetch_add(1, Ordering::AcqRel);
-    self.assert_has_capacity_for(idx);
+// default pinned vector -> SplitVec<T, Doubling>
+let bag: ConcurrentBag<char> = ConcurrentBag::new();
+let bag: ConcurrentBag<char> = Default::default();
+let bag: ConcurrentBag<char> = ConcurrentBag::with_doubling_growth();
+let bag: ConcurrentBag<char, SplitVec<char, Doubling>> = ConcurrentBag::with_doubling_growth();
 
-    loop {
-        let capacity = self.capacity.load(Ordering::Relaxed);
+let bag: ConcurrentBag<char> = SplitVec::new().into();
+let bag: ConcurrentBag<char, SplitVec<char, Doubling>> = SplitVec::new().into();
 
-        match idx.cmp(&capacity) {
-            // no need to grow, just push
-            std::cmp::Ordering::Less => {
-                self.write(idx, value);
-                break;
-            }
+// SplitVec with [Linear](https://docs.rs/orx-split-vec/latest/orx_split_vec/struct.Linear.html) growth
+// each fragment will have capacity 2^10 = 1024
+// and the split vector can grow up to 32 fragments
+let bag: ConcurrentBag<char, SplitVec<char, Linear>> = ConcurrentBag::with_linear_growth(10, 32);
+let bag: ConcurrentBag<char, SplitVec<char, Linear>> = SplitVec::with_linear_growth_and_fragments_capacity(10, 32).into();
 
-            // we are responsible for growth
-            std::cmp::Ordering::Equal => {
-                let new_capacity = self.grow_to(capacity + 1);
-                self.capacity.store(new_capacity, Ordering::Relaxed);
-                self.write(idx, value);
-                break;
-            }
-
-            // spin to wait for responsible thread to handle growth
-            std::cmp::Ordering::Greater => {}
-        }
-    }
-
-    idx
-}
+// [FixedVec](https://docs.rs/orx-fixed-vec/latest/orx_fixed_vec/) with fixed capacity.
+// Fixed vector cannot grow; hence, pushing the 1025-th element to this bag will cause a panic!
+let bag: ConcurrentBag<char, FixedVec<char>> = ConcurrentBag::with_fixed_capacity(1024);
+let bag: ConcurrentBag<char, FixedVec<char>> = FixedVec::new(1024).into();
 ```
 
-Below are some details about this implementation:
-* `fetch_add` guarantees that each pushed `value` receives a unique idx.
-* `assert_has_capacity_for` method is an additional safety guarantee added to pinned vectors to prevent any possible UB. It is not constraining for practical usage, see [`ConcurrentBag::maximum_capacity`] for details.
-* Inside the loop, we read the current `capacity` and compare it with `idx`:
-  * `idx < capacity`:
-    * The `idx`-th position is already allocated and belongs to the bag. We can simply write. Note that concurrent bag is write-only. Therefore, there is no other thread writing to or reading from this position; and hence, no race condition is present.
-  * `idx > capacity`:
-    * The `idx`-th position is not yet allocated. Underlying pinned vector needs to grow.
-    * But another thread is responsible for the growth, we simply wait.
-  * `idx == capacity`:
-    * The `idx`-th position is not yet allocated. Underlying pinned vector needs to grow.
-    * Further, we are responsible for the growth. Note that this guarantees that:
-      * Only one thread will make the growth calls.
-      * Only one growth call can take place at a given time.
-      * There exists no race condition for the growth.
-    * We first grow the pinned vector, then write to the `idx`-th position, and finally update the `capacity` to the new capacity.
+Of course, the pinned vector to be wrapped does not need to be empty.
+
+```rust
+use orx_concurrent_bag::*;
+
+let split_vec: SplitVec<i32> = (0..1024).collect();
+let bag: ConcurrentBag<_> = split_vec.into();
+```
+
+# Concurrent State and Properties
+
+The concurrent state is modeled simply by an atomic length. Combination of this state and `PinnedConcurrentCol` leads to the following properties:
+* Writing to a position of the collection does not block other writes, multiple writes can happen concurrently.
+* Each position is written exactly once.
+* ⟹ no write & write race condition exists.
+* Only one growth can happen at a given time.
+* Underlying pinned vector is always valid and can be taken out any time by `into_inner(self)`.
+* Reading is only possible after converting the bag into the underlying `PinnedVec`.
+* ⟹ no read & write race condition exists.
 
 <div id="section-benchmarks"></div>
 
-# C. Benchmarks
+# Benchmarks
 
 ## Performance with `push`
 
@@ -125,7 +116,7 @@ The issue leading to poor performance in the *small data & little work* situatio
 
 <img src="https://raw.githubusercontent.com/orxfun/orx-concurrent-bag/main/docs/img/bench_collect_with_push.PNG" alt="https://raw.githubusercontent.com/orxfun/orx-concurrent-bag/main/docs/img/bench_collect_with_push.PNG" />
 
-## Performance of `extend`
+## Performance with `extend`
 
 *You may find the details of the benchmarks at [benches/collect_with_extend.rs](https://github.com/orxfun/orx-concurrent-bag/blob/main/benches/collect_with_extend.rs).*
 
@@ -155,33 +146,31 @@ for j in (0..num_items_per_thread).step_by(batch_size) {
 
 <div id="section-performance-notes"></div>
 
-# D. Performance Notes
+## Performance Notes
 
-## How many times and how long we spin?
+### How many times and how long we spin?
 
-Consider the `push` method, implementation of which is provided above. We will spin in the `std::cmp::Ordering::Greater => {}` branch. Fortunately, number of times we will spin is **deterministic**. It is exactly equal to the number of growth calls of the underlying pinned vector, and pinned vector implementations give a detailed control on this. For instance, assume that we will push a total of 15_000 elements concurrently to an empty bag.
+There is only one waiting or spinning condition of the push and extend methods: whenever the underlying pinned vector needs to grow. Note that growth with pinned vector is copy free. Therefore, when it spins, all it waits for is the allocation. Further, note that number of times we will allocate, and hence spin, is deterministic. 
 
-* Further assume we use the default `SplitVec<_, Doubling>` as the underlying pinned vector. Throughout the execution, we will allocate fragments of capacities [4, 8, 16, ..., 4096, 8192] which will lead to a total capacity of 16_380. In other words, we might possibly visit the `std::cmp::Ordering::Greater => {}` block in 12 points in time during the entire execution.
-* If we use a `SplitVec<_, Linear>` with constant fragment lengths of 1_024, we will allocate 15 equal capacity fragments, which will lead to a total capacity of 15_360. So looping might only happen 15 times. We can drop this number to 8 if we set constant fragment capacity to 2_048; i.e., we can control the frequency of allocations.
+For instance, assume that we will push a total of 15_000 elements concurrently to an empty bag.
+
+* Further assume we use the default `SplitVec<_, Doubling>` as the underlying pinned vector. Throughout the execution, we will allocate fragments of capacities [4, 8, 16, ..., 4096, 8192] which will lead to a total capacity of 16_380. In other words, we will allocate exactly 12 times during the entire execution.
+* If we use a `SplitVec<_, Linear>` with constant fragment lengths of 1_024, we will allocate 15 equal capacity fragments.
 * If we use the strict `FixedVec<_>`, we have to pre-allocate a safe amount and can never grow beyond this number. Therefore, there will never be any spinning.
 
-When we spin, we do not spin long because:
-* Pinned vectors do not change memory locations of already pushed elements. In other words, growths are copy-free.
-* We are only waiting for allocation of memory required for the growth with respect to the chosen growth strategy.
-
-## False Sharing and How to Avoid
+### False Sharing and How to Avoid
 
 [`ConcurrentBag::push`] method is implementation is simple, lock-free and efficient. However, we need to be aware of the potential [false sharing](https://en.wikipedia.org/wiki/False_sharing) risk which might lead to significant performance degradation. Fortunately, it is possible to avoid in many cases.
 
-### When?
+#### When?
 
-Performance degradation due to false sharing might be observed when both of the following conditions hold:
+Performance degradation due to false sharing might be observed specifically when both of the following conditions hold:
 * **small data**: data to be pushed is small, the more elements fitting in a cache line the bigger the risk,
 * **little work**: multiple threads/cores are pushing to the concurrent bag with high frequency; i.e., very little or negligible work / time is required in between `push` calls.
 
 The example above fits this situation. Each thread only performs one multiplication and addition in between pushing elements, and the elements to be pushed are very small, just one `usize`.
 
-### Why?
+#### Why?
 
 * `ConcurrentBag` assigns unique positions to each value to be pushed. There is no *true* sharing among threads in the position level.
 * However, cache lines contain more than one position.
@@ -191,7 +180,7 @@ The example above fits this situation. Each thread only performs one multiplicat
 
 Following two methods could be approached to deal with this problem.
 
-### Solution-I: `extend` rather than `push`
+#### Solution-I: `extend` rather than `push`
 
 One very simple, effective and memory efficient solution to this problem is to use [`ConcurrentBag::extend`] rather than `push` in *small data & little work* situations.
 
@@ -228,51 +217,9 @@ std::thread::scope(|s| {
 });
 ```
 
-### Solution-II: Padding
+#### Solution-II: Padding
 
 Another common approach to deal with false sharing is to add padding (unused bytes) between elements. There exist wrappers which automatically adds cache padding, such as crossbeam's [`CachePadded`](https://docs.rs/crossbeam-utils/latest/crossbeam_utils/struct.CachePadded.html). In other words, instead of using a `ConcurrentBag<T>`, we can use `ConcurrentBag<CachePadded<T>>`. However, this solution leads to increased memory requirement.
-
-<div id="section-construction-and-conversions"></div>
-
-# E. `From` | `into_inner`
-
-`ConcurrentBag` can be constructed by wrapping any pinned vector; i.e., `ConcurrentBag<T>` implements `From<P: PinnedVec<T>>`.
-Likewise, a concurrent vector can be unwrapped without any cost to the underlying pinned vector with `into_inner` method.
-
-Further, there exist `with_` methods to directly construct the concurrent bag with common pinned vector implementations.
-
-```rust
-use orx_concurrent_bag::*;
-
-// default pinned vector -> SplitVec<T, Doubling>
-let bag: ConcurrentBag<char> = ConcurrentBag::new();
-let bag: ConcurrentBag<char> = Default::default();
-let bag: ConcurrentBag<char> = ConcurrentBag::with_doubling_growth();
-let bag: ConcurrentBag<char, SplitVec<char, Doubling>> = ConcurrentBag::with_doubling_growth();
-
-let bag: ConcurrentBag<char> = SplitVec::new().into();
-let bag: ConcurrentBag<char, SplitVec<char, Doubling>> = SplitVec::new().into();
-
-// SplitVec with [Linear](https://docs.rs/orx-split-vec/latest/orx_split_vec/struct.Linear.html) growth
-// each fragment will have capacity 2^10 = 1024
-// and the split vector can grow up to 32 fragments
-let bag: ConcurrentBag<char, SplitVec<char, Linear>> = ConcurrentBag::with_linear_growth(10, 32);
-let bag: ConcurrentBag<char, SplitVec<char, Linear>> = SplitVec::with_linear_growth_and_fragments_capacity(10, 32).into();
-
-// [FixedVec](https://docs.rs/orx-fixed-vec/latest/orx_fixed_vec/) with fixed capacity.
-// Fixed vector cannot grow; hence, pushing the 1025-th element to this bag will cause a panic!
-let bag: ConcurrentBag<char, FixedVec<char>> = ConcurrentBag::with_fixed_capacity(1024);
-let bag: ConcurrentBag<char, FixedVec<char>> = FixedVec::new(1024).into();
-```
-
-Of course, the pinned vector to be wrapped does not need to be empty.
-
-```rust
-use orx_concurrent_bag::*;
-
-let split_vec: SplitVec<i32> = (0..1024).collect();
-let bag: ConcurrentBag<_> = split_vec.into();
-```
 
 # License
 

--- a/src/bag.rs
+++ b/src/bag.rs
@@ -1,20 +1,20 @@
-use crate::errors::{ERR_FAILED_TO_GROW, ERR_FAILED_TO_PUSH, ERR_REACHED_MAX_CAPACITY};
-use orx_fixed_vec::FixedVec;
-use orx_pinned_vec::{PinnedVec, PinnedVecGrowthError};
-use orx_split_vec::{Doubling, Linear, SplitVec};
-use std::cell::UnsafeCell;
-use std::marker::PhantomData;
-use std::sync::atomic::{AtomicUsize, Ordering};
+use crate::state::ConcurrentBagState;
+use orx_pinned_concurrent_col::PinnedConcurrentCol;
+use orx_pinned_vec::PinnedVec;
+use orx_split_vec::{Doubling, SplitVec};
+use std::ops::{Deref, DerefMut};
 
-/// An efficient, convenient and lightweight grow-only concurrent collection, ideal for collecting results concurrently.
+/// An efficient, convenient and lightweight grow-only concurrent data structure allowing high performance concurrent collection.
 ///
-/// * **convenient**: `ConcurrentBag` can safely be shared among threads simply as a shared reference. Further, it is just a wrapper around any [`PinnedVec`](https://crates.io/crates/orx-pinned-vec) implementation adding concurrent safety guarantees. Therefore, underlying pinned vector and concurrent bag can be converted to each other back and forth without any cost.
-/// * **lightweight**: This crate takes a simplistic approach built on pinned vector guarantees which leads to concurrent programs with few dependencies and small binaries.
-/// * **efficient**: `ConcurrentBag` is a lock free structure making use of a few atomic primitives, this leads to high performance growth.
+/// * **convenient**: `ConcurrentBag` can safely be shared among threads simply as a shared reference. It is a [`PinnedConcurrentCol`](https://crates.io/crates/orx-pinned-concurrent-col) with a special concurrent state implementation. Underlying [`PinnedVec`](https://crates.io/crates/orx-pinned-vec) and concurrent bag can be converted back and forth to each other.
+/// * **efficient**: `ConcurrentBag` is a lock free structure making use of a few atomic primitives, this leads to high performance concurrent growth. You may see the details in <a href="#section-benchmarks">benchmarks</a> and further <a href="#section-performance-notes">performance notes</a>.
+///
+/// Note that `ConcurrentBag` is write only (with the safe api), see [`ConcurrentVec`](https://crates.io/crates/orx-concurrent-vec) for a read & write variant.
 ///
 /// # Examples
 ///
-/// Safety guarantees to push to the bag with a shared reference makes it easy to share the bag among threads. `std::sync::Arc` can be used; however, it is not required as demonstrated below.
+/// Safety guarantees to push to the bag with a shared reference makes it easy to share the bag among threads.
+/// `std::sync::Arc` can be used; however, it is not required as demonstrated below.
 ///
 /// ```rust
 /// use orx_concurrent_bag::*;
@@ -42,80 +42,7 @@ use std::sync::atomic::{AtomicUsize, Ordering};
 /// assert_eq!(vec_from_bag, expected);
 /// ```
 ///
-/// <div id="section-approach-and-safety"></div>
-///
-/// # Approach and Safety
-///
-/// `ConcurrentBag` aims to enable concurrent growth with a minimalistic approach. It requires two major components for this:
-/// * The underlying storage, which is any `PinnedVec` implementation. This means that memory locations of elements that are already pushed to the vector will never change, unless explicitly changed. This guarantee eliminates a certain set of safety concerns and corresponding complexity.
-/// * An atomic counter that is responsible for uniquely assigning one vector position to one and only one thread. `std::sync::atomic::AtomicUsize` and its `fetch_add` method are sufficient for this.
-///
-/// Simplicity and safety of the approach can be observed in the implementation of the `push` method.
-///
-/// ```rust ignore
-/// pub fn push(&self, value: T) -> usize {
-///     let idx = self.len.fetch_add(1, Ordering::AcqRel);
-///     self.assert_has_capacity_for(idx);
-///
-///     loop {
-///         let capacity = self.capacity.load(Ordering::Relaxed);
-///
-///         match idx.cmp(&capacity) {
-///             // no need to grow, just push
-///             std::cmp::Ordering::Less => {
-///                 self.write(idx, value);
-///                 break;
-///             }
-///
-///             // we are responsible for growth
-///             std::cmp::Ordering::Equal => {
-///                 let new_capacity = self.grow_to(capacity + 1);
-///                 self.write(idx, value);
-///                 self.capacity.store(new_capacity, Ordering::Relaxed);
-///                 break;
-///             }
-///
-///             // spin to wait for responsible thread to handle growth
-///             std::cmp::Ordering::Greater => {}
-///         }
-///     }
-///
-///     idx
-/// }
-/// ```
-///
-/// Below are some details about this implementation:
-/// * `fetch_add` guarantees that each pushed `value` receives a unique idx.
-/// * `assert_has_capacity_for` method is an additional safety guarantee added to pinned vectors to prevent any possible UB. It is not constraining for practical usage, see [`ConcurrentBag::maximum_capacity`] for details.
-/// * Inside the loop, we read the current `capacity` and compare it with `idx`:
-///   * `idx < capacity`:
-///     * The `idx`-th position is already allocated and belongs to the bag. We can simply write. Note that concurrent bag is write-only. Therefore, there is no other thread writing to or reading from this position; and hence, no race condition is present.
-///   * `idx > capacity`:
-///     * The `idx`-th position is not yet allocated. Underlying pinned vector needs to grow.
-///     * But another thread is responsible for the growth, we simply wait.
-///   * `idx == capacity`:
-///     * The `idx`-th position is not yet allocated. Underlying pinned vector needs to grow.
-///     * Further, we are responsible for the growth. Note that this guarantees that:
-///       * Only one thread will make the growth calls.
-///       * Only one growth call can take place at a given time.
-///       * There exists no race condition for the growth.
-///     * We first grow the pinned vector, then write to the `idx`-th position, and finally update the `capacity` to the new capacity.
-///
-/// ## How many times will we spin?
-///
-/// This is **deterministic**. It is exactly equal to the number of growth calls of the underlying pinned vector, and pinned vector implementations give a detailed control on this. For instance, assume that we will push a total of 15_000 elements concurrently to an empty bag.
-///
-/// * Further assume we use the default `SplitVec<_, Doubling>` as the underlying pinned vector. Throughout the execution, we will allocate fragments of capacities [4, 8, 16, ..., 4096, 8192] which will lead to a total capacity of 16_380. In other words, we might possibly visit the `std::cmp::Ordering::Greater => {}` block in 12 points in time during the entire execution.
-/// * If we use a `SplitVec<_, Linear>` with constant fragment lengths of 1_024, we will allocate 15 equal capacity fragments, which will lead to a total capacity of 15_360. So looping might only happen 15 times. We can drop this number to 8 if we set constant fragment capacity to 2_048; i.e., we can control the frequency of allocations.
-/// * If we use the strict `FixedVec<_>`, we have to pre-allocate a safe amount and can never grow beyond this number. Therefore, there will never be any spinning.
-///
-/// ## When we spin, how long do we spin?
-///
-/// Not long because:
-/// * Pinned vectors do not change memory locations of already pushed elements. In other words, growths are copy-free.
-/// * We are only waiting for allocation of memory required for the growth with respect to the chosen growth strategy.
-///
-/// # Construction
+/// ## Construction
 ///
 /// `ConcurrentBag` can be constructed by wrapping any pinned vector; i.e., `ConcurrentBag<T>` implements `From<P: PinnedVec<T>>`.
 /// Likewise, a concurrent vector can be unwrapped without any cost to the underlying pinned vector with `into_inner` method.
@@ -154,140 +81,24 @@ use std::sync::atomic::{AtomicUsize, Ordering};
 /// let split_vec: SplitVec<i32> = (0..1024).collect();
 /// let bag: ConcurrentBag<_> = split_vec.into();
 /// ```
+///
+/// # Concurrent State and Properties
+///
+/// The concurrent state is modeled simply by an atomic length.
+/// Combination of this state and `PinnedConcurrentCol` leads to the following properties:
+/// * Writing to the collection does not block. Multiple writes can happen concurrently.
+/// * Each position is written only and exactly once.
+/// * Only one growth can happen at a given time.
+/// * Underlying pinned vector can be extracted any time.
+/// * Safe reading is only possible after converting the bag into the underlying `PinnedVec`.
+/// No read & write race condition exists.
 pub struct ConcurrentBag<T, P = SplitVec<T, Doubling>>
 where
     P: PinnedVec<T>,
 {
-    phantom: PhantomData<T>,
-    pinned: UnsafeCell<P>,
-    maximum_capacity: UnsafeCell<usize>,
-    zero_memory: bool,
-    len: AtomicUsize,
-    capacity: AtomicUsize,
+    core: PinnedConcurrentCol<T, P, ConcurrentBagState>,
 }
 
-// new
-impl<T> ConcurrentBag<T, SplitVec<T, Doubling>> {
-    /// Creates a new concurrent bag by creating and wrapping up a new `SplitVec<T, Doubling>` as the underlying storage.
-    pub fn with_doubling_growth() -> Self {
-        Self::new_from_pinned(
-            SplitVec::with_doubling_growth_and_fragments_capacity(32),
-            false,
-        )
-    }
-
-    /// Creates a new concurrent bag by creating and wrapping up a new `SplitVec<T, Doubling>` as the underlying storage.
-    pub fn new() -> Self {
-        Self::with_doubling_growth()
-    }
-}
-
-impl<T> Default for ConcurrentBag<T, SplitVec<T, Doubling>> {
-    /// Creates a new concurrent bag by creating and wrapping up a new `SplitVec<T, Doubling>` as the underlying storage.
-    fn default() -> Self {
-        Self::with_doubling_growth()
-    }
-}
-
-impl<T> ConcurrentBag<T, SplitVec<T, Linear>> {
-    /// Creates a new concurrent bag by creating and wrapping up a new `SplitVec<T, Linear>` as the underlying storage.
-    ///
-    /// # Notes
-    ///
-    /// * `Linear` can be chosen over `Doubling` whenever memory efficiency is more critical since linear allocations lead to less waste.
-    /// * Choosing a small `constant_fragment_capacity_exponent` for a large bag to be filled might lead to too many growth calls.
-    /// * Furthermore, `Linear` growth strategy leads to a hard upper bound on the maximum capacity, please see the Safety section.
-    ///
-    /// # Safety
-    ///
-    /// `SplitVec<T, Linear>` can grow indefinitely (almost).
-    ///
-    /// However, `ConcurrentBag<T, SplitVec<T, Linear>>` has an upper bound on its capacity.
-    /// This capacity is computed as:
-    ///
-    /// ```rust ignore
-    /// 2usize.pow(constant_fragment_capacity_exponent) * fragments_capacity
-    /// ```
-    ///
-    /// For instance maximum capacity is 2^10 * 64 = 65536 when `constant_fragment_capacity_exponent=10` and `fragments_capacity=64`.
-    ///
-    /// Note that setting a relatively high and safe `fragments_capacity` is **not** costly, size of each element 2*usize.
-    ///
-    /// Pushing to the vector beyond this capacity leads to "out-of-capacity" error.
-    ///
-    /// This maximum capacity can be accessed by [`ConcurrentBag::maximum_capacity`] method.
-    pub fn with_linear_growth(
-        constant_fragment_capacity_exponent: usize,
-        fragments_capacity: usize,
-    ) -> Self {
-        Self::new_from_pinned(
-            SplitVec::with_linear_growth_and_fragments_capacity(
-                constant_fragment_capacity_exponent,
-                fragments_capacity,
-            ),
-            false,
-        )
-    }
-}
-
-impl<T> ConcurrentBag<T, FixedVec<T>> {
-    /// Creates a new concurrent bag by creating and wrapping up a new `FixedVec<T>` as the underlying storage.
-    ///
-    /// # Safety
-    ///
-    /// Note that a `FixedVec` cannot grow; i.e., it has a hard upper bound on the number of elements it can hold, which is the `fixed_capacity`.
-    ///
-    /// Pushing to the vector beyond this capacity leads to "out-of-capacity" error.
-    ///
-    /// This maximum capacity can be accessed by [`ConcurrentBag::maximum_capacity`] method.
-    pub fn with_fixed_capacity(fixed_capacity: usize) -> Self {
-        Self::new_from_pinned(FixedVec::new(fixed_capacity), false)
-    }
-}
-
-impl<T, P> From<P> for ConcurrentBag<T, P>
-where
-    P: PinnedVec<T>,
-{
-    /// `ConcurrentBag<T>` wraps any `PinnedVec<T>` implementation.
-    ///
-    /// Therefore, without a cost
-    /// * `ConcurrentBag<T>` can be constructed from any `PinnedVec<T>`, and
-    /// * the underlying `PinnedVec<T>` can be obtained by `ConcurrentBag::into_inner(self)` method.
-    fn from(value: P) -> Self {
-        Self::new_from_pinned(value, false)
-    }
-}
-
-impl<T, P> ConcurrentBag<T, P>
-where
-    P: PinnedVec<T>,
-{
-    /// Converts the given `PinnedVec<T>` implementation into a concurrent bag with memory zeroing.
-    ///
-    /// Note that default [`ConcurrentBag::zeroes_memory_on_allocation`] strategy of a `ConcurrentBag` is `false`.
-    /// This is similar to dynamic size containers such as vectors and it is safe since:
-    /// * `ConcurrentBag` does not have a safe api to read elements while they are being concurrently written.
-    /// * Safe reading only happens by converting the bag into the underlying pinned vector by the consuming `into_inner` method.
-    /// * Therefore, it is not possible to access an uninitialized memory.
-    ///
-    /// On the other hand, if the caller decides to use unsafe reading methods such as `get` or `iter`, it might be preferred to zero memory on each allocation.
-    /// However, these methods would be considered safe only if the corresponding type has a valid zero value; i.e., `std::mem::zeroed()`.
-    ///
-    /// A nice and useful example to this is the `Option<T>`.
-    /// * It has a valid `std::mem::zeroed()` value which is `None`.
-    /// * We can safely call the `get(i)` method:
-    ///   * if another thread has reserved this position but has not written the value yet, we would receive `None`;
-    ///   * otherwise, we would get `Some(value)`.
-    /// This is the way [`ConcurrentVec`](https://crates.io/crates/orx-concurrent-vec) provides safe `get` and `iter` methods.
-    ///
-    /// Of course, zeroing out new positions at each allocation might have a performance impact for very large collections; hence, it is not the default method.
-    pub fn new_with_mem_zeroing(pinned_vec: P) -> Self {
-        Self::new_from_pinned(pinned_vec, true)
-    }
-}
-
-// impl
 impl<T, P> ConcurrentBag<T, P>
 where
     P: PinnedVec<T>,
@@ -327,17 +138,10 @@ where
     /// let split = bag.into_inner();
     /// assert!(split.is_empty());
     pub fn into_inner(self) -> P {
-        unsafe { self.correct_pinned_len() };
-        self.pinned.into_inner()
-    }
-
-    /// Returns whether or not new allocated positions are zeroed out immediately after bag capacity is increased.
-    ///
-    /// Note that the default strategy is `false`.
-    ///
-    /// In order to create a concurrent bag which zeroes out memory upon allocation, use the [`ConcurrentBag::new_with_mem_zeroing`] method.
-    pub fn zeroes_memory_on_allocation(&self) -> bool {
-        self.zero_memory
+        let len = self.core.state().len();
+        // # SAFETY: ConcurrentBag only allows to push to the end of the bag, keeping track of the length.
+        // Therefore, the underlying pinned vector is in a valid condition at any given time.
+        unsafe { self.core.into_inner(len) }
     }
 
     /// ***O(1)*** Returns the number of elements which are pushed to the bag, including the elements which received their reserved locations and are currently being pushed.
@@ -355,181 +159,10 @@ where
     /// ```
     #[inline(always)]
     pub fn len(&self) -> usize {
-        self.len.load(Ordering::SeqCst)
+        self.core.state().len()
     }
 
-    /// ***O(1)*** Returns the current capacity of the concurrent bag; i.e., the underlying pinned vector storage.
-    ///
-    /// # Examples
-    ///
-    /// ```rust
-    /// use orx_concurrent_bag::ConcurrentBag;
-    ///
-    /// let bag = ConcurrentBag::new();
-    /// bag.push('a');
-    /// bag.push('b');
-    ///
-    /// assert_eq!(4, bag.capacity());
-    ///
-    /// bag.push('c');
-    /// bag.push('d');
-    /// bag.push('e');
-    ///
-    /// assert_eq!(12, bag.capacity());
-    /// ```
-    #[inline(always)]
-    pub fn capacity(&self) -> usize {
-        self.capacity.load(Ordering::Relaxed)
-    }
-
-    /// Note that a `ConcurrentBag` contains two capacity methods:
-    /// * `capacity`: returns current capacity of the underlying pinned vector; this capacity can grow concurrently with a `&self` reference; i.e., during a `push` call
-    /// * `maximum_capacity`: returns the maximum potential capacity that the pinned vector can grow up to with a `&self` reference;
-    ///   * `push`ing a new element while the bag is at `maximum_capacity` leads to panic.
-    ///
-    /// On the other hand, maximum capacity can safely be increased by a mutually exclusive `&mut self` reference using the `reserve_maximum_capacity`.
-    /// However, underlying pinned vector must be able to provide pinned-element guarantees during this operation.
-    ///
-    /// Among the common pinned vector implementations:
-    /// * `SplitVec<_, Doubling>`: supports this method; however, it does not require for any practical size.
-    /// * `SplitVec<_, Linear>`: is guaranteed to succeed and increase its maximum capacity to the required value.
-    /// * `FixedVec<_>`: is the most strict pinned vector which cannot grow even in a single-threaded setting. Currently, it will always return an error to this call.
-    ///
-    /// # Examples
-    ///
-    /// ```rust
-    /// use orx_concurrent_bag::*;
-    /// use orx_pinned_vec::PinnedVecGrowthError;
-    ///
-    ///  // SplitVec<_, Doubling> (default)
-    /// let bag: ConcurrentBag<char> = ConcurrentBag::new();
-    /// assert_eq!(bag.capacity(), 4); // only allocates the first fragment of 4
-    /// assert_eq!(bag.maximum_capacity(), 17_179_869_180); // it can grow safely & exponentially
-    ///
-    /// let bag: ConcurrentBag<char, _> = ConcurrentBag::with_doubling_growth();
-    /// assert_eq!(bag.capacity(), 4);
-    /// assert_eq!(bag.maximum_capacity(), 17_179_869_180);
-    ///
-    /// // SplitVec<_, Linear>
-    /// let mut bag: ConcurrentBag<char, _> = ConcurrentBag::with_linear_growth(10, 20);
-    /// assert_eq!(bag.capacity(), 2usize.pow(10)); // only allocates first fragment of 1024
-    /// assert_eq!(bag.maximum_capacity(), 2usize.pow(10) * 20); // it can concurrently allocate 19 more
-    ///
-    /// // SplitVec<_, Linear> -> reserve_maximum_capacity
-    /// let result = bag.reserve_maximum_capacity(2usize.pow(10) * 30);
-    /// assert_eq!(result, Ok(2usize.pow(10) * 30));
-    ///
-    /// // actually no new allocation yet; precisely additional memory for 10 pairs of pointers is used
-    /// assert_eq!(bag.capacity(), 2usize.pow(10)); // still only the first fragment capacity
-    ///
-    /// assert_eq!(bag.maximum_capacity(), 2usize.pow(10) * 30); // now it can safely reach 2^10 * 30
-    ///
-    /// // FixedVec<_>: pre-allocated, exact and strict
-    /// let mut bag: ConcurrentBag<char, _> = ConcurrentBag::with_fixed_capacity(42);
-    /// assert_eq!(bag.capacity(), 42);
-    /// assert_eq!(bag.maximum_capacity(), 42);
-    ///
-    /// let result = bag.reserve_maximum_capacity(43);
-    /// assert_eq!(
-    ///     result,
-    ///     Err(PinnedVecGrowthError::FailedToGrowWhileKeepingElementsPinned)
-    /// );
-    /// ```
-    pub fn reserve_maximum_capacity(
-        &mut self,
-        maximum_capacity: usize,
-    ) -> Result<usize, PinnedVecGrowthError> {
-        let result = self.try_grow_to(maximum_capacity);
-        if let Ok(new_capacity) = result {
-            let maximum_capacity = unsafe { &mut *self.maximum_capacity.get() };
-            *maximum_capacity = new_capacity;
-        }
-        result
-    }
-
-    /// Returns the maximum possible capacity that the concurrent bag can reach.
-    /// This is equivalent to the maximum capacity that the underlying pinned vector can safely reach in a concurrent program.
-    ///
-    /// Note that `maximum_capacity` differs from `capacity` due to the following:
-    /// * `capacity` represents currently allocated memory owned by the underlying pinned vector.
-    /// The bag can possibly grow beyond this value.
-    /// * `maximum_capacity` represents the hard upper limit on the length of the concurrent bag.
-    /// Attempting to grow the bag beyond this value leads to an error.
-    /// Note that this is not necessarily a limitation for the underlying split vector; the limitation might be due to the additional safety requirements of concurrent programs.
-    ///
-    /// # Safety
-    ///
-    /// Calling `push` while the bag is at its `maximum_capacity` leads to a panic.    
-    /// This condition is a safety requirement.
-    /// Underlying pinned vector cannot safely grow beyond maximum capacity in a possibly concurrent call (with `&self`).
-    /// This would lead to UB.
-    ///
-    /// It is easy to overcome this problem during construction:
-    /// * It is not observed with the default pinned vector `SplitVec<_, Doubling>`:
-    ///   * `ConcurrentBag::new()`
-    ///   * `ConcurrentBag::with_doubling_growth()`
-    /// * It can be avoided cheaply when `SplitVec<_, Linear>` is used by setting the second argument to a proper value:
-    ///   * `ConcurrentBag::with_linear_growth(10, 32)`
-    ///     * Each fragment of this vector will have a capacity of 2^10 = 1024.
-    ///     * It can safely grow up to 32 fragments with `&self` reference.
-    ///     * Therefore, it is safe to concurrently grow this vector to 32 * 1024 elements.
-    ///     * Cost of replacing 32 with 64 is negligible in such a scenario (the difference in memory allocation is precisely 32 * 2*usize).
-    /// * Using the variant `FixedVec<_>` requires a hard bound and pre-allocation regardless the program is concurrent or not.
-    ///   * `ConcurrentBag::with_fixed_capacity(1024)`
-    ///     * Unlike the split vector variants, this variant pre-allocates for 1024 elements.
-    ///     * And can never grow beyond this value.
-    ///
-    /// Alternatively, caller can try to safely reserve the required capacity any time by a mutually exclusive reference:
-    /// * `ConcurrentBag.reserve_maximum_capacity(&mut self, maximum_capacity: usize)`
-    ///   * this call will always succeed with `SplitVec<_, Doubling>` and `SplitVec<_, Linear>`,
-    ///   * will always fail for `FixedVec<_>`.
-    ///
-    /// # Examples
-    ///
-    /// ```rust
-    /// use orx_concurrent_bag::*;
-    /// use orx_pinned_vec::PinnedVecGrowthError;
-    ///
-    ///  // SplitVec<_, Doubling> (default)
-    /// let bag: ConcurrentBag<char> = ConcurrentBag::new();
-    /// assert_eq!(bag.capacity(), 4); // only allocates the first fragment of 4
-    /// assert_eq!(bag.maximum_capacity(), 17_179_869_180); // it can grow safely & exponentially
-    ///
-    /// let bag: ConcurrentBag<char, _> = ConcurrentBag::with_doubling_growth();
-    /// assert_eq!(bag.capacity(), 4);
-    /// assert_eq!(bag.maximum_capacity(), 17_179_869_180);
-    ///
-    /// // SplitVec<_, Linear>
-    /// let mut bag: ConcurrentBag<char, _> = ConcurrentBag::with_linear_growth(10, 20);
-    /// assert_eq!(bag.capacity(), 2usize.pow(10)); // only allocates first fragment of 1024
-    /// assert_eq!(bag.maximum_capacity(), 2usize.pow(10) * 20); // it can concurrently allocate 19 more
-    ///
-    /// // SplitVec<_, Linear> -> reserve_maximum_capacity
-    /// let result = bag.reserve_maximum_capacity(2usize.pow(10) * 30);
-    /// assert_eq!(result, Ok(2usize.pow(10) * 30));
-    ///
-    /// // actually no new allocation yet; precisely additional memory for 10 pairs of pointers is used
-    /// assert_eq!(bag.capacity(), 2usize.pow(10)); // still only the first fragment capacity
-    ///
-    /// assert_eq!(bag.maximum_capacity(), 2usize.pow(10) * 30); // now it can safely reach 2^10 * 30
-    ///
-    /// // FixedVec<_>: pre-allocated, exact and strict
-    /// let mut bag: ConcurrentBag<char, _> = ConcurrentBag::with_fixed_capacity(42);
-    /// assert_eq!(bag.capacity(), 42);
-    /// assert_eq!(bag.maximum_capacity(), 42);
-    ///
-    /// let result = bag.reserve_maximum_capacity(43);
-    /// assert_eq!(
-    ///     result,
-    ///     Err(PinnedVecGrowthError::FailedToGrowWhileKeepingElementsPinned)
-    /// );
-    /// ```
-    #[inline]
-    pub fn maximum_capacity(&self) -> usize {
-        unsafe { *self.maximum_capacity.get() }
-    }
-
-    /// Returns whether the bag is empty or not.
+    /// Returns whether or not the bag is empty.
     ///
     /// # Examples
     ///
@@ -542,6 +175,7 @@ where
     ///
     /// bag.push('a');
     /// bag.push('b');
+    ///
     /// assert!(!bag.is_empty());
     ///
     /// bag.clear();
@@ -552,57 +186,17 @@ where
         self.len() == 0
     }
 
-    /// Returns an iterator to elements of the bag.
-    ///
-    /// Iteration of elements is in the order the push method is called.
-    ///
-    /// # Safety
-    ///
-    /// This method is unsafe due to the possibility of the following scenario:
-    /// * a thread reserves a position in the bag,
-    /// * this increases the length of the bag by one, which includes this new element to the iteration,
-    /// * however, before writing the value of the element completes, iterator reaches this element and reads uninitialized value.
-    ///
-    /// Note that [`ConcurrentBag`] is meant to be write-only, or even, grow-only.
-    /// See [`ConcurrentVec`](https://crates.io/crates/orx-concurrent-vec) for a read-and-write variant which
-    /// * guarantees that reading and writing never happen concurrently, and hence,
-    /// * allows safe iteration or access to already written elements of the concurrent vector,
-    /// * with a minor additional cost of values being wrapped by an `Option`.
-    ///
-    /// # Examples
-    ///
-    /// ```rust
-    /// use orx_concurrent_bag::ConcurrentBag;
-    ///
-    /// let bag = ConcurrentBag::new();
-    /// bag.push('a');
-    /// bag.push('b');
-    ///
-    /// let mut iter = unsafe { bag.iter() };
-    /// assert_eq!(iter.next(), Some(&'a'));
-    /// assert_eq!(iter.next(), Some(&'b'));
-    /// assert_eq!(iter.next(), None);
-    /// ```
-    pub unsafe fn iter(&self) -> impl Iterator<Item = &T> {
-        self.correct_pinned_len();
-        let pinned = &*self.pinned.get() as &P;
-        pinned.iter().take(self.len())
-    }
-
     /// Returns a reference to the element at the `index`-th position of the bag.
     /// It returns `None` when index is out of bounds.
     ///
     /// # Safety
     ///
-    /// `ConcurrentBag` guarantees that each position is written exactly once by a single thread.
+    /// `ConcurrentBag` guarantees that each position is written only and exactly once.
     /// And further, no thread reads this position (see [`ConcurrentVec`](https://crates.io/crates/orx-concurrent-vec) for a safe read & write variant).
     /// Therefore, there exists no race condition.
     ///
-    /// On the other, hand `get` method partially breaks this by allowing reading.
-    /// Although it is still not very likely to have a race condition, there still exists a possibility which would lead to a race condition and UB.
-    /// Therefore, this method is `unsafe`.
-    ///
-    /// The race condition could be observed in the following situation. Say we have a `bag` of `char`s and we allocate memory to store incoming characters, say 4 positions.
+    /// The race condition could be observed in the following unsafe usage.
+    /// Say we have a `bag` of `char`s and we allocate memory to store incoming characters, say 4 positions.
     /// If the following events happen in the exact order in time, we might have undefined behavior (UB):
     /// * `bag.push('a')` is called from thread#1.
     /// * `bag` atomically increases the `len` to 1.
@@ -676,19 +270,49 @@ where
     /// assert_eq!(averages.len(), 10);
     /// ```
     pub unsafe fn get(&self, index: usize) -> Option<&T> {
-        if index < self.len() && index < self.capacity() {
-            let pinned = unsafe { &mut *self.pinned.get() };
-            let ptr = unsafe { pinned.get_ptr_mut(index) };
-            ptr.and_then(|x| x.as_ref())
+        if index < self.len() {
+            unsafe { self.core.get(index) }
         } else {
             None
         }
     }
 
-    // mutate collection
+    /// Returns an iterator to elements of the bag.
+    ///
+    /// Iteration of elements is in the order the push method is called.
+    ///
+    /// # Safety
+    ///
+    /// This method is unsafe due to the possibility of the following scenario:
+    /// * a thread reserves a position in the bag,
+    /// * this increases the length of the bag by one, which includes this new element to the iteration,
+    /// * however, before writing the value of the element completes, iterator reaches this element and reads uninitialized value.
+    ///
+    /// Note that [`ConcurrentBag`] is meant to be write-only, or even, grow-only.
+    /// See [`ConcurrentVec`](https://crates.io/crates/orx-concurrent-vec) for a read-and-write variant which
+    /// * guarantees that reading and writing never happen concurrently, and hence,
+    /// * allows safe iteration or access to already written elements of the concurrent vector,
+    /// * with a minor additional cost of values being wrapped by an `Option`.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use orx_concurrent_bag::ConcurrentBag;
+    ///
+    /// let bag = ConcurrentBag::new();
+    /// bag.push('a');
+    /// bag.push('b');
+    ///
+    /// let mut iter = unsafe { bag.iter() };
+    /// assert_eq!(iter.next(), Some(&'a'));
+    /// assert_eq!(iter.next(), Some(&'b'));
+    /// assert_eq!(iter.next(), None);
+    /// ```
+    pub unsafe fn iter(&self) -> impl Iterator<Item = &T> {
+        self.core.iter(self.len())
+    }
 
-    /// Concurrent, thread-safe method to push the given `value` to the back of the bag,
-    /// and returns the position or index of the pushed value.
+    /// Concurrent, thread-safe method to push the given `value` to the back of the bag, and returns the position or index of the pushed value.
     ///
     /// It preserves the order of elements with respect to the order the `push` method is called.
     ///
@@ -697,11 +321,11 @@ where
     /// Panics if the concurrent bag is already at its maximum capacity; i.e., if `self.len() == self.maximum_capacity()`.
     ///
     /// Note that this is an important safety assertion in the concurrent context; however, not a practical limitation.
-    /// Please see the [`ConcurrentBag::maximum_capacity`] for details.
+    /// Please see the [`PinnedConcurrentCol::maximum_capacity`] for details.
     ///
     /// # Examples
     ///
-    /// We can directly take a shared reference of the bag and share it among threads.
+    /// We can directly take a shared reference of the bag, share it among threads and collect results concurrently.
     ///
     /// ```rust
     /// use orx_concurrent_bag::*;
@@ -733,9 +357,10 @@ where
     ///
     /// # Performance Notes - False Sharing
     ///
-    /// [`ConcurrentBag::push`] method is implementation is simple, lock-free and efficient.
+    /// [`ConcurrentBag::push`] implementation is lock-free and focuses on efficiency.
     /// However, we need to be aware of the potential [false sharing](https://en.wikipedia.org/wiki/False_sharing) risk.
-    /// False sharing might lead to significant performance degradation; fortunately, it is possible to avoid in many cases.
+    /// False sharing might lead to significant performance degradation.
+    /// However, it is possible to avoid in many cases.
     ///
     /// ## When?
     ///
@@ -812,38 +437,14 @@ where
     ///
     /// ## Solution-II: Padding
     ///
-    /// Another common approach to deal with false sharing is to add padding (unused bytes) between elements.
+    /// Another approach to deal with false sharing is to add padding (unused bytes) between elements.
     /// There exist wrappers which automatically adds cache padding, such as crossbeam's [`CachePadded`](https://docs.rs/crossbeam-utils/latest/crossbeam_utils/struct.CachePadded.html).
     /// In other words, instead of using a `ConcurrentBag<T>`, we can use `ConcurrentBag<CachePadded<T>>`.
     /// However, this solution leads to increased memory requirement.
     pub fn push(&self, value: T) -> usize {
-        let idx = self.len.fetch_add(1, Ordering::AcqRel);
-        self.assert_has_capacity_for(idx);
-
-        #[allow(clippy::never_loop)]
-        loop {
-            let capacity = self.capacity.load(Ordering::Relaxed);
-
-            match idx.cmp(&capacity) {
-                // no need to grow, just write
-                std::cmp::Ordering::Less => {
-                    self.write(idx, value);
-                    break;
-                }
-
-                // we are responsible for growth
-                std::cmp::Ordering::Equal => {
-                    let new_capacity = self.grow_to(capacity + 1);
-                    self.capacity.store(new_capacity, Ordering::Relaxed);
-                    self.write(idx, value);
-                    break;
-                }
-
-                // spin to wait for responsible thread to handle growth
-                std::cmp::Ordering::Greater => {}
-            }
-        }
-
+        let idx = self.core.state().fetch_increment_len(1);
+        // # SAFETY: ConcurrentBag ensures that each `idx` will be written only and exactly once.
+        unsafe { self.core.write(idx, value) };
         idx
     }
 
@@ -857,20 +458,22 @@ where
     /// * and the last value will be written to the `begin_idx + values.count() - 1`-th position of the bag.
     ///
     /// Important notes:
-    /// * This method does not allocate at all to buffer elements to be pushed.
+    /// * This method does not allocate to buffer.
     /// * All it does is to increment the atomic counter by the length of the iterator (`push` would increment by 1) and reserve the range of positions for this operation.
-    /// * Iterating over and writing elements to the bag happens afterwards.
-    /// * This is a simple, effective and memory efficient solution to the false sharing problem which could be observed in *small data & little work* situations.
+    /// * If there is not sufficient space, the vector grows first; iterating over and writing elements to the bag happens afterwards.
+    /// * Therefore, other threads do not wait for the `extend` method to complete, they can concurrently write.
+    /// * This is a simple and effective approach to deal with the false sharing problem which could be observed in *small data & little work* situations.
     ///
     /// For this reason, the method requires an `ExactSizeIterator`.
-    /// There exists the variant [`ConcurrentBag::extend_n_items`] method which accepts any iterator together with the correct length to be passed by the caller, hence it is `unsafe`.
+    /// There exists the variant [`ConcurrentBag::extend_n_items`] method which accepts any iterator together with the correct length to be passed by the caller.
+    /// It is `unsafe` as the caller must guarantee that the iterator yields at least the number of elements explicitly passed in as an argument.
     ///
     /// # Panics
     ///
     /// Panics if not all of the `values` fit in the concurrent bag's maximum capacity.
     ///
     /// Note that this is an important safety assertion in the concurrent context; however, not a practical limitation.
-    /// Please see the [`ConcurrentBag::maximum_capacity`] for details.
+    /// Please see the [`PinnedConcurrentCol::maximum_capacity`] for details.
     ///
     /// # Examples
     ///
@@ -967,6 +570,7 @@ where
     {
         let values = values.into_iter();
         let num_items = values.len();
+        // # SAFETY: ConcurrentBag ensures that each `idx` will be written only and exactly once.
         unsafe { self.extend_n_items::<_>(values, num_items) }
     }
 
@@ -993,7 +597,7 @@ where
     /// Panics if `num_items` elements do not fit in the concurrent bag's maximum capacity.
     ///
     /// Note that this is an important safety assertion in the concurrent context; however, not a practical limitation.
-    /// Please see the [`ConcurrentBag::maximum_capacity`] for details.
+    /// Please see the [`PinnedConcurrentCol::maximum_capacity`] for details.
     ///
     /// # Safety
     ///
@@ -1104,544 +708,52 @@ where
     where
         IntoIter: IntoIterator<Item = T>,
     {
-        let values = values.into_iter();
-
-        let beg_idx = self.len.fetch_add(num_items, Ordering::AcqRel);
-        let new_len = beg_idx + num_items;
-        let end_idx = new_len - 1;
-
-        self.assert_has_capacity_for(end_idx);
-
-        loop {
-            let capacity = self.capacity.load(Ordering::Relaxed);
-
-            match (beg_idx.cmp(&capacity), end_idx.cmp(&capacity)) {
-                // no need to grow, just write
-                (_, std::cmp::Ordering::Less) => {
-                    self.write_many(beg_idx, values);
-                    break;
-                }
-
-                // spin to wait for responsible thread to handle growth
-                (std::cmp::Ordering::Greater, _) => {}
-
-                // we are responsible for growth
-                _ => {
-                    let new_capacity = self.grow_to(new_len);
-                    self.capacity.store(new_capacity, Ordering::Relaxed);
-                    self.write_many(beg_idx, values);
-                    break;
-                }
-            }
-        }
-
-        beg_idx
+        let begin_idx = self.core.state().fetch_increment_len(num_items);
+        self.core.write_n_items(begin_idx, num_items, values);
+        begin_idx
     }
+}
 
-    /// Clears the bag removing all already pushed elements.
-    ///
-    /// # Safety
-    ///
-    /// This method requires a mutually exclusive reference.
-    /// This guarantees that there might not be any continuing writing process of a `push` operation.
-    /// Therefore, the elements can safely be cleared.
-    ///
-    /// # Examples
-    ///
-    /// ```rust
-    /// use orx_concurrent_bag::ConcurrentBag;
-    ///
-    /// let mut bag = ConcurrentBag::new();
-    ///
-    /// bag.push('a');
-    /// bag.push('b');
-    ///
-    /// bag.clear();
-    /// assert!(bag.is_empty());
-    /// ```
-    pub fn clear(&mut self) {
-        let pinned = self.pinned.get_mut();
-        pinned.clear();
-        let capacity = pinned.capacity();
+// HELPERS
 
-        self.capacity.store(capacity, Ordering::SeqCst);
-        self.len.store(0, Ordering::SeqCst);
-    }
-
-    // helpers
-    fn new_from_pinned(pinned: P, zero_memory: bool) -> Self {
-        let len = pinned.len();
-
-        let mut pinned = pinned;
-        unsafe { pinned.set_len(0) };
-
-        Self {
-            len: len.into(),
-            capacity: pinned.capacity().into(),
-            maximum_capacity: pinned.capacity_state().maximum_concurrent_capacity().into(),
-            pinned: pinned.into(),
-            zero_memory,
-            phantom: Default::default(),
-        }
-    }
-
-    /// Asserts that `idx < self.maximum_capacity()`.
-    ///
-    /// # Safety
-    ///
-    /// This condition is a safety requirement.
-    /// Underlying pinned vector cannot safely grow beyond maximum capacity in a possibly concurrent call (`&self`).
-    /// This would lead to UB.
-    ///
-    /// It is easy to overcome this problem during construction:
-    /// * It is not observed with the default pinned vector `SplitVec<_, Doubling>`:
-    ///   * `ConcurrentBag::new()`
-    ///   * `ConcurrentBag::with_doubling_growth()`
-    /// * It can be avoided cheaply when `SplitVec<_, Linear>` is used by setting the second argument to a proper value:
-    ///   * `ConcurrentBag::with_linear_growth(10, 32)`
-    ///     * Each fragment of this vector will have a capacity of 2^10 = 1024.
-    ///     * It can safely grow up to 32 fragments with `&self` reference.
-    ///     * Therefore, it is safe to concurrently grow this vector to 32 * 1024 elements.
-    ///     * Cost of replacing 32 with 64 is negligible in such a scenario (the difference in memory allocation is precisely 32 * 2*usize).
-    /// * Using the variant `FixedVec<_>` requires a hard bound and pre-allocation regardless the program is concurrent or not.
-    ///   * `ConcurrentBag::with_fixed_capacity(1024)`
-    ///     * Unlike the split vector variants, this variant pre-allocates for 1024 elements.
-    ///     * And can never grow beyond this value.
-    ///
-    /// Alternatively, caller can try to safely reserve the required capacity any time by a mutually exclusive reference:
-    /// * `ConcurrentBag.reserve_maximum_capacity(&mut self, maximum_capacity: usize)`
-    ///   * this call will always succeed with `SplitVec<_, Doubling>` and `SplitVec<_, Linear>`,
-    ///   * will always fail for `FixedVec<_>`.
+impl<T, P> ConcurrentBag<T, P>
+where
+    P: PinnedVec<T>,
+{
     #[inline]
-    fn assert_has_capacity_for(&self, idx: usize) {
-        assert!(
-            idx < self.maximum_capacity(),
-            "{}",
-            ERR_REACHED_MAX_CAPACITY
-        );
+    pub(crate) fn new_from_pinned(pinned_vec: P) -> Self {
+        let core = PinnedConcurrentCol::new_from_pinned(pinned_vec);
+        Self { core }
     }
 
     #[inline]
-    fn try_grow_to(&self, new_capacity: usize) -> Result<usize, PinnedVecGrowthError> {
-        let pinned = unsafe { &mut *self.pinned.get() };
-        unsafe { pinned.grow_to(new_capacity, self.zero_memory) }
+    pub(crate) fn core(&self) -> &PinnedConcurrentCol<T, P, ConcurrentBagState> {
+        &self.core
     }
+}
 
-    #[inline]
-    fn grow_to(&self, new_capacity: usize) -> usize {
-        self.try_grow_to(new_capacity).expect(ERR_FAILED_TO_GROW)
+// TRAITS
+
+impl<T, P> Deref for ConcurrentBag<T, P>
+where
+    P: PinnedVec<T>,
+{
+    type Target = PinnedConcurrentCol<T, P, ConcurrentBagState>;
+
+    fn deref(&self) -> &Self::Target {
+        &self.core
     }
+}
 
-    #[inline]
-    pub(crate) fn write(&self, idx: usize, value: T) {
-        let pinned = unsafe { &mut *self.pinned.get() };
-        let ptr = unsafe { pinned.get_ptr_mut(idx) }.expect(ERR_FAILED_TO_PUSH);
-        unsafe { std::ptr::write(ptr, value) };
-    }
-
-    fn write_many<Iter: Iterator<Item = T>>(&self, beg_idx: usize, values: Iter) {
-        for (i, value) in values.enumerate() {
-            self.write(beg_idx + i, value);
-        }
-    }
-
-    pub(crate) unsafe fn correct_pinned_len(&self) {
-        let pinned = unsafe { &mut *self.pinned.get() };
-        unsafe { pinned.set_len(self.len()) };
+impl<T, P> DerefMut for ConcurrentBag<T, P>
+where
+    P: PinnedVec<T>,
+{
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.core
     }
 }
 
 unsafe impl<T: Sync, P: PinnedVec<T>> Sync for ConcurrentBag<T, P> {}
 
 unsafe impl<T: Send, P: PinnedVec<T>> Send for ConcurrentBag<T, P> {}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-    use orx_split_vec::Recursive;
-    use std::{
-        collections::HashSet,
-        sync::{Arc, Mutex},
-        time::Duration,
-    };
-
-    #[test]
-    fn new_len_empty_clear() {
-        fn test<P: PinnedVec<char>>(bag: ConcurrentBag<char, P>) {
-            assert!(!bag.zeroes_memory_on_allocation());
-
-            let mut bag = bag;
-
-            assert!(bag.is_empty());
-            assert_eq!(0, bag.len());
-
-            bag.push('a');
-
-            assert!(!bag.is_empty());
-            assert_eq!(1, bag.len());
-
-            bag.push('b');
-            bag.push('c');
-            bag.push('d');
-
-            assert!(!bag.is_empty());
-            assert_eq!(4, bag.len());
-
-            bag.clear();
-            assert!(bag.is_empty());
-            assert_eq!(0, bag.len());
-        }
-
-        test(ConcurrentBag::new());
-        test(ConcurrentBag::default());
-        test(ConcurrentBag::with_doubling_growth());
-        test(ConcurrentBag::with_linear_growth(2, 8));
-        test(ConcurrentBag::with_linear_growth(4, 8));
-        test(ConcurrentBag::with_fixed_capacity(64));
-    }
-
-    #[test]
-    fn new_with_mem_zeroing() {
-        fn test<P: PinnedVec<char>>(pinned_vec: P) {
-            let bag = ConcurrentBag::new_with_mem_zeroing(pinned_vec);
-            assert!(bag.zeroes_memory_on_allocation());
-        }
-
-        test(SplitVec::new());
-        test(SplitVec::with_doubling_growth());
-        test(SplitVec::with_linear_growth_and_fragments_capacity(2, 8));
-        test(FixedVec::new(64));
-    }
-
-    #[test]
-    fn capacity() {
-        let mut split: SplitVec<_, Doubling> = (0..4).collect();
-        split.concurrent_reserve(5);
-        let bag: ConcurrentBag<_, _> = split.into();
-        assert_eq!(bag.capacity(), 4);
-        bag.push(42);
-        assert_eq!(bag.capacity(), 12);
-
-        let mut split: SplitVec<_, Recursive> = (0..4).collect();
-        split.concurrent_reserve(5);
-        let bag: ConcurrentBag<_, _> = split.into();
-        assert_eq!(bag.capacity(), 4);
-        bag.push(42);
-        assert_eq!(bag.capacity(), 12);
-
-        let mut split: SplitVec<_, Linear> = SplitVec::with_linear_growth(2);
-        split.extend_from_slice(&[0, 1, 2, 3]);
-        split.concurrent_reserve(5);
-        let bag: ConcurrentBag<_, _> = split.into();
-        assert_eq!(bag.capacity(), 4);
-        bag.push(42);
-        assert_eq!(bag.capacity(), 8);
-
-        let mut fixed: FixedVec<_> = FixedVec::new(5);
-        fixed.extend_from_slice(&[0, 1, 2, 3]);
-        let bag: ConcurrentBag<_, _> = fixed.into();
-        assert_eq!(bag.capacity(), 5);
-        bag.push(42);
-        assert_eq!(bag.capacity(), 5);
-    }
-
-    #[test]
-    #[should_panic]
-    fn exceeding_fixed_capacity_panics() {
-        let mut fixed: FixedVec<_> = FixedVec::new(5);
-        fixed.extend_from_slice(&[0, 1, 2, 3]);
-        let bag: ConcurrentBag<_, _> = fixed.into();
-        assert_eq!(bag.capacity(), 5);
-        bag.push(42);
-        bag.push(7);
-    }
-
-    #[test]
-    #[should_panic]
-    fn exceeding_fixed_capacity_panics_concurrently() {
-        let bag = ConcurrentBag::with_fixed_capacity(10);
-        let bag_ref = &bag;
-        std::thread::scope(|s| {
-            for _ in 0..4 {
-                s.spawn(move || {
-                    for _ in 0..3 {
-                        // in total there will be 4*3 = 12 pushes
-                        bag_ref.push(42);
-                    }
-                });
-            }
-        });
-    }
-
-    #[test]
-    fn get() {
-        // record measurements in (assume) random intervals
-        let measurements = ConcurrentBag::<i32>::new();
-        let rf_measurements = &measurements;
-
-        // collect sum of measurements every 50 milliseconds
-        let sums = ConcurrentBag::new();
-        let rf_sums = &sums;
-
-        // collect average of measurements every 50 milliseconds
-        let averages = ConcurrentBag::new();
-        let rf_averages = &averages;
-
-        std::thread::scope(|s| {
-            s.spawn(move || {
-                for i in 0..100 {
-                    std::thread::sleep(Duration::from_millis(i % 5));
-                    rf_measurements.push(i as i32);
-                }
-            });
-
-            s.spawn(move || {
-                for _ in 0..10 {
-                    let mut sum = 0;
-                    for i in 0..rf_measurements.len() {
-                        sum += unsafe { rf_measurements.get(i) }.copied().unwrap_or(0);
-                    }
-                    rf_sums.push(sum);
-                    std::thread::sleep(Duration::from_millis(50));
-                }
-            });
-
-            s.spawn(move || {
-                for _ in 0..10 {
-                    let count = rf_measurements.len();
-                    if count == 0 {
-                        rf_averages.push(0.0);
-                    } else {
-                        let mut sum = 0;
-                        for i in 0..rf_measurements.len() {
-                            sum += unsafe { rf_measurements.get(i) }.copied().unwrap_or(0);
-                        }
-                        let average = sum as f32 / count as f32;
-                        rf_averages.push(average);
-                    }
-                    std::thread::sleep(Duration::from_millis(50));
-                }
-            });
-        });
-
-        assert_eq!(measurements.len(), 100);
-        assert_eq!(sums.len(), 10);
-        assert_eq!(averages.len(), 10);
-    }
-
-    #[test]
-    fn iter() {
-        let mut bag = ConcurrentBag::new();
-
-        assert_eq!(0, unsafe { bag.iter() }.count());
-
-        bag.push('a');
-
-        assert_eq!(
-            vec!['a'],
-            unsafe { bag.iter() }.copied().collect::<Vec<_>>()
-        );
-
-        bag.push('b');
-        bag.push('c');
-        bag.push('d');
-
-        assert_eq!(
-            vec!['a', 'b', 'c', 'd'],
-            unsafe { bag.iter() }.copied().collect::<Vec<_>>()
-        );
-
-        bag.clear();
-        assert_eq!(0, unsafe { bag.iter() }.count());
-    }
-
-    #[test]
-    fn into_inner_from() {
-        let bag = ConcurrentBag::new();
-
-        bag.push('a');
-        bag.push('b');
-        bag.push('c');
-        bag.push('d');
-        assert_eq!(
-            vec!['a', 'b', 'c', 'd'],
-            unsafe { bag.iter() }.copied().collect::<Vec<_>>()
-        );
-
-        let mut split = bag.into_inner();
-        assert_eq!(
-            vec!['a', 'b', 'c', 'd'],
-            split.iter().copied().collect::<Vec<_>>()
-        );
-
-        split.push('e');
-        *split.get_mut(0).expect("exists") = 'x';
-
-        assert_eq!(
-            vec!['x', 'b', 'c', 'd', 'e'],
-            split.iter().copied().collect::<Vec<_>>()
-        );
-
-        let mut bag: ConcurrentBag<_> = split.into();
-        assert_eq!(
-            vec!['x', 'b', 'c', 'd', 'e'],
-            unsafe { bag.iter() }.copied().collect::<Vec<_>>()
-        );
-
-        bag.clear();
-        assert!(bag.is_empty());
-
-        let split = bag.into_inner();
-        assert!(split.is_empty());
-    }
-
-    #[test]
-    fn ok_at_num_threads() {
-        use std::thread::available_parallelism;
-        let default_parallelism_approx = available_parallelism().expect("is-ok").get();
-
-        let num_threads = default_parallelism_approx;
-        let num_items_per_thread = 16384;
-
-        let bag = ConcurrentBag::new();
-        let bag_ref = &bag;
-        std::thread::scope(|s| {
-            for i in 0..num_threads {
-                s.spawn(move || {
-                    for j in 0..num_items_per_thread {
-                        bag_ref.push((i * 100000 + j) as i32);
-                    }
-                });
-            }
-        });
-
-        let pinned = bag.into_inner();
-        assert_eq!(pinned.len(), num_threads * num_items_per_thread);
-    }
-
-    #[test]
-    fn push_indices() {
-        let num_threads = 4;
-        let num_items_per_thread = 16;
-
-        let indices_set = Arc::new(Mutex::new(HashSet::new()));
-
-        let bag = ConcurrentBag::new();
-        let bag_ref = &bag;
-        std::thread::scope(|s| {
-            for i in 0..num_threads {
-                let indices_set = indices_set.clone();
-                s.spawn(move || {
-                    for j in 0..num_items_per_thread {
-                        let idx = bag_ref.push(i * 100000 + j);
-                        let mut set = indices_set.lock().expect("is ok");
-                        set.insert(idx);
-                    }
-                });
-            }
-        });
-
-        let set = indices_set.lock().expect("is ok");
-        assert_eq!(set.len(), 4 * 16);
-        for i in 0..(4 * 16) {
-            assert!(set.contains(&i));
-        }
-    }
-
-    #[test]
-    fn reserve_maximum_capacity() {
-        // SplitVec<_, Doubling>
-        let bag: ConcurrentBag<char> = ConcurrentBag::new();
-        assert_eq!(bag.capacity(), 4); // only allocates the first fragment of 4
-        assert_eq!(bag.maximum_capacity(), 17_179_869_180); // it can grow safely & exponentially
-
-        let bag: ConcurrentBag<char, _> = ConcurrentBag::with_doubling_growth();
-        assert_eq!(bag.capacity(), 4);
-        assert_eq!(bag.maximum_capacity(), 17_179_869_180);
-
-        // SplitVec<_, Linear>
-        let mut bag: ConcurrentBag<char, _> = ConcurrentBag::with_linear_growth(10, 20);
-        assert_eq!(bag.capacity(), 2usize.pow(10)); // only allocates first fragment of 1024
-        assert_eq!(bag.maximum_capacity(), 2usize.pow(10) * 20); // it can concurrently allocate 19 more
-
-        // SplitVec<_, Linear> -> reserve_maximum_capacity
-        let result = bag.reserve_maximum_capacity(2usize.pow(10) * 30);
-        assert_eq!(result, Ok(2usize.pow(10) * 30));
-
-        // actually no new allocation yet; precisely additional memory for 10 pairs of pointers is used
-        assert_eq!(bag.capacity(), 2usize.pow(10)); // first fragment capacity
-
-        assert_eq!(bag.maximum_capacity(), 2usize.pow(10) * 30); // now it can safely reach 2^10 * 30
-
-        // FixedVec<_>: pre-allocated, exact and strict
-        let mut bag: ConcurrentBag<char, _> = ConcurrentBag::with_fixed_capacity(42);
-        assert_eq!(bag.capacity(), 42);
-        assert_eq!(bag.maximum_capacity(), 42);
-
-        let result = bag.reserve_maximum_capacity(43);
-        assert_eq!(
-            result,
-            Err(PinnedVecGrowthError::FailedToGrowWhileKeepingElementsPinned)
-        );
-    }
-
-    #[test]
-    fn extend_indices() {
-        let num_threads = 4;
-        let num_items_per_thread = 16;
-
-        let indices_set = Arc::new(Mutex::new(HashSet::new()));
-
-        let bag = ConcurrentBag::new();
-        let bag_ref = &bag;
-        std::thread::scope(|s| {
-            for i in 0..num_threads {
-                let indices_set = indices_set.clone();
-                s.spawn(move || {
-                    let iter = (0..num_items_per_thread).map(|j| i * 100000 + j);
-
-                    let begin_idx = bag_ref.extend(iter);
-
-                    let mut set = indices_set.lock().expect("is ok");
-                    set.insert(begin_idx);
-                });
-            }
-        });
-
-        let set = indices_set.lock().expect("is ok");
-        assert_eq!(set.len(), num_threads);
-        for i in 0..num_threads {
-            assert!(set.contains(&(i * num_items_per_thread)));
-        }
-    }
-
-    #[test]
-    fn extend_n_items_indices() {
-        let num_threads = 4;
-        let num_items_per_thread = 16;
-
-        let indices_set = Arc::new(Mutex::new(HashSet::new()));
-
-        let bag = ConcurrentBag::new();
-        let bag_ref = &bag;
-        std::thread::scope(|s| {
-            for i in 0..num_threads {
-                let indices_set = indices_set.clone();
-                s.spawn(move || {
-                    let iter = (0..num_items_per_thread).map(|j| i * 100000 + j);
-
-                    let begin_idx = unsafe { bag_ref.extend_n_items(iter, num_items_per_thread) };
-
-                    let mut set = indices_set.lock().expect("is ok");
-                    set.insert(begin_idx);
-                });
-            }
-        });
-
-        let set = indices_set.lock().expect("is ok");
-        assert_eq!(set.len(), num_threads);
-        for i in 0..num_threads {
-            assert!(set.contains(&(i * num_items_per_thread)));
-        }
-    }
-}

--- a/src/common_traits/debug.rs
+++ b/src/common_traits/debug.rs
@@ -4,13 +4,8 @@ use std::fmt::Debug;
 
 impl<T: Debug, P: PinnedVec<T>> Debug for ConcurrentBag<T, P> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        unsafe { self.correct_pinned_len() };
-
         f.debug_struct("ConcurrentBag")
-            .field("pinned", &unsafe { self.iter().collect::<Vec<_>>() })
-            .field("len", &self.len())
-            .field("capacity", &self.capacity())
-            .field("maximum_capacity", &self.maximum_capacity())
+            .field("core", self.core())
             .finish()
     }
 }
@@ -32,7 +27,7 @@ mod tests {
         let str = format!("{:?}", bag);
         assert_eq!(
             str,
-            "ConcurrentBag { pinned: ['a', 'b', 'c', 'd', 'e'], len: 5, capacity: 12, maximum_capacity: 17179869180 }"
+            "ConcurrentBag { core: PinnedConcurrentCol { pinned_vec: \"PinnedVec\", state: ConcurrentBagState { len: 5 }, capacity: CapacityState { capacity: 12, maximum_capacity: 17179869180 } } }"
         );
     }
 }

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -1,6 +1,0 @@
-pub(crate) const ERR_FAILED_TO_GROW: &str =
-    "The underlying pinned vector reached its capacity and failed to grow";
-
-pub(crate) const ERR_FAILED_TO_PUSH: &str = "Failed to push new element to the concurrent bag";
-
-pub(crate) const ERR_REACHED_MAX_CAPACITY: &str = "Out of capacity. Underlying pinned vector cannot grow any further while being concurrently safe.";

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,17 +5,16 @@
 //!
 //! An efficient, convenient and lightweight grow-only concurrent data structure allowing high performance concurrent collection.
 //!
-//! * **convenient**: `ConcurrentBag` can safely be shared among threads simply as a shared reference. Further, it is just a wrapper around any [`PinnedVec`](https://crates.io/crates/orx-pinned-vec) implementation adding concurrent safety guarantees. Therefore, underlying pinned vector and concurrent bag can be converted to each other back and forth without any cost (see <a href="#section-construction-and-conversions">construction and conversions</a>).
-//! * **lightweight**: This crate takes a simplistic approach built on pinned vector guarantees which leads to concurrent programs with few dependencies and small binaries (see <a href="#section-approach-and-safety">approach and safety</a> for details).
-//! * **efficient**: `ConcurrentBag` is a lock free structure making use of atomic primitives, this leads to high performance growth. You may see the details in <a href="#section-benchmarks">benchmarks</a> and further <a href="#section-performance-notes">performance notes</a>.
+//! * **convenient**: `ConcurrentBag` can safely be shared among threads simply as a shared reference. It is a [`PinnedConcurrentCol`](https://crates.io/crates/orx-pinned-concurrent-col) with a special concurrent state implementation. Underlying [`PinnedVec`](https://crates.io/crates/orx-pinned-vec) and concurrent bag can be converted back and forth to each other.
+//! * **efficient**: `ConcurrentBag` is a lock free structure making use of a few atomic primitives, this leads to high performance concurrent growth. You may see the details in <a href="#section-benchmarks">benchmarks</a> and further <a href="#section-performance-notes">performance notes</a>.
 //!
-//! Note that `ConcurrentBag` is a **write only** collection which is optimized for high performance concurrent collection. When we need to safely read elements while the collection concurrently grows, [`ConcurrentVec`](https://crates.io/crates/orx-concurrent-vec) is preferable due to its additional safety guarantees. Having almost identical api, switching between `ConcurrentBag` and `ConcurrentVec` is straightforward.
+//! Note that `ConcurrentBag` is write only (with the safe api), see [`ConcurrentVec`](https://crates.io/crates/orx-concurrent-vec) for a read & write variant.
 //!
-//! # A. Examples
+//! # Examples
 //!
 //! Safety guarantees to push to the bag with a shared reference makes it easy to share the bag among threads. `std::sync::Arc` can be used; however, it is not required as demonstrated below.
 //!
-//! ```rust
+//!  ```rust
 //! use orx_concurrent_bag::*;
 //!
 //! let (num_threads, num_items_per_thread) = (4, 1_024);
@@ -23,221 +22,29 @@
 //! let bag = ConcurrentBag::new();
 //!
 //! // just take a reference and share among threads
-//! let bag_ref = &bag;
+//! let con_bag = &bag;
 //!
 //! std::thread::scope(|s| {
 //!     for i in 0..num_threads {
 //!         s.spawn(move || {
 //!             for j in 0..num_items_per_thread {
 //!                 // concurrently collect results simply by calling `push`
-//!                 bag_ref.push(i * 1000 + j);
+//!                 con_bag.push(i * 1000 + j);
 //!             }
 //!         });
 //!     }
 //! });
 //!
-//! assert_eq!(bag.len(), num_threads * num_items_per_thread);
-//!
-//! let pinned_vec = bag.into_inner();
-//! assert_eq!(pinned_vec.len(), num_threads * num_items_per_thread);
+//! let mut vec_from_bag: Vec<_> = bag.into_inner().iter().copied().collect();
+//! vec_from_bag.sort();
+//! let mut expected: Vec<_> = (0..num_threads).flat_map(|i| (0..num_items_per_thread).map(move |j| i * 1000 + j)).collect();
+//! expected.sort();
+//! assert_eq!(vec_from_bag, expected);
 //! ```
 //!
-//! <div id="section-approach-and-safety"></div>
+//! ### Construction
 //!
-//! # B. Approach and Safety
-//!
-//! `ConcurrentBag` aims to enable concurrent growth with a minimalistic approach. It requires two major components for this:
-//! * The underlying storage, which is any `PinnedVec` implementation. Pinned vectors guarantee that memory locations of its elements will never change, unless explicitly changed. This guarantee eliminates a certain set of safety concerns and corresponding complexity.
-//! * An atomic counter that is responsible for uniquely assigning one vector position to one and only one thread. `std::sync::atomic::AtomicUsize` and its `fetch_add` method are sufficient for this.
-//!
-//! Simplicity and safety of the approach can be observed in the implementation of the `push` method.
-//!
-//! ```rust ignore
-//! pub fn push(&self, value: T) -> usize {
-//!     let idx = self.len.fetch_add(1, Ordering::AcqRel);
-//!     self.assert_has_capacity_for(idx);
-//!
-//!     loop {
-//!         let capacity = self.capacity.load(Ordering::Relaxed);
-//!
-//!         match idx.cmp(&capacity) {
-//!             // no need to grow, just push
-//!             std::cmp::Ordering::Less => {
-//!                 self.write(idx, value);
-//!                 break;
-//!             }
-//!
-//!             // we are responsible for growth
-//!             std::cmp::Ordering::Equal => {
-//!                 let new_capacity = self.grow_to(capacity + 1);
-//!                 self.capacity.store(new_capacity, Ordering::Relaxed);
-//!                 self.write(idx, value);
-//!                 break;
-//!             }
-//!
-//!             // spin to wait for responsible thread to handle growth
-//!             std::cmp::Ordering::Greater => {}
-//!         }
-//!     }
-//!
-//!     idx
-//! }
-//! ```
-//!
-//! Below are some details about this implementation:
-//! * `fetch_add` guarantees that each pushed `value` receives a unique idx.
-//! * `assert_has_capacity_for` method is an additional safety guarantee added to pinned vectors to prevent any possible UB. It is not constraining for practical usage, see [`ConcurrentBag::maximum_capacity`] for details.
-//! * Inside the loop, we read the current `capacity` and compare it with `idx`:
-//!   * `idx < capacity`:
-//!     * The `idx`-th position is already allocated and belongs to the bag. We can simply write. Note that concurrent bag is write-only. Therefore, there is no other thread writing to or reading from this position; and hence, no race condition is present.
-//!   * `idx > capacity`:
-//!     * The `idx`-th position is not yet allocated. Underlying pinned vector needs to grow.
-//!     * But another thread is responsible for the growth, we simply wait.
-//!   * `idx == capacity`:
-//!     * The `idx`-th position is not yet allocated. Underlying pinned vector needs to grow.
-//!     * Further, we are responsible for the growth. Note that this guarantees that:
-//!       * Only one thread will make the growth calls.
-//!       * Only one growth call can take place at a given time.
-//!       * There exists no race condition for the growth.
-//!     * We first grow the pinned vector, then write to the `idx`-th position, and finally update the `capacity` to the new capacity.
-//!
-//! <div id="section-benchmarks"></div>
-//!
-//! # C. Benchmarks
-//!
-//! ## Performance with `push`
-//!
-//! *You may find the details of the benchmarks at [benches/collect_with_push.rs](https://github.com/orxfun/orx-concurrent-bag/blob/main/benches/collect_with_push.rs).*
-//!
-//! In the experiment, `rayon`s parallel iterator and `ConcurrentBag`s `push` method are used to collect results from multiple threads.
-//!
-//! ```rust ignore
-//! // reserve and push one position at a time
-//! for j in 0..num_items_per_thread {
-//!     bag_ref.push(i * 1000 + j);
-//! }
-//! ```
-//!
-//! * We observe that rayon is significantly faster when the output is very small (`i32` in this experiment).
-//! * As the output gets larger and copies become costlier (`[i32; 32]` here), `ConcurrentBag::push` starts to outperform.
-//!
-//! The issue leading to poor performance in the *small data & little work* situation can be avoided by using `extend` method in such cases. You may see its impact in the succeeding subsections and related reasons in the <a href="#section-performance-notes">performance notes</a>.
-//!
-//! <img src="https://raw.githubusercontent.com/orxfun/orx-concurrent-bag/main/docs/img/bench_collect_with_push.PNG" alt="https://raw.githubusercontent.com/orxfun/orx-concurrent-bag/main/docs/img/bench_collect_with_push.PNG" />
-//!
-//! ## Performance of `extend`
-//!
-//! *You may find the details of the benchmarks at [benches/collect_with_extend.rs](https://github.com/orxfun/orx-concurrent-bag/blob/main/benches/collect_with_extend.rs).*
-//!
-//! The only difference in this follow up experiment is that we use `extend` rather than `push` with `ConcurrentBag`. The expectation is that this approach will solve the performance degradation due to false sharing in the *small data & little work* situation.
-//!
-//! ```rust ignore
-//! // reserve num_items_per_thread positions at a time
-//! // and then push as the iterator yields
-//! let iter = (0..num_items_per_thread).map(|j| i * 100000 + j);
-//! bag_ref.extend(iter);
-//! ```
-//!
-//! We now observe that `ConcurrentBag` is comparable to, if not faster than, rayon's parallel iterator in the small data case. The performance improvement is less dramatic but still significant in the larger output size case.
-//!
-//! <img src="https://raw.githubusercontent.com/orxfun/orx-concurrent-bag/main/docs/img/bench_collect_with_extend.PNG" alt="https://raw.githubusercontent.com/orxfun/orx-concurrent-bag/main/docs/img/bench_collect_with_extend.PNG" />
-//!
-//! Note that we do not need to have perfect information on the number of items to be pushed per thread to get the benefits of `extend`, we can simply `step_by`. Extending by `batch_size` elements will already prevent the dramatic performance degradation provided that `batch_size` elements exceed a cache line.
-//!
-//! ```rust ignore
-//! // reserve batch_size positions at a time
-//! // and then push as the iterator yields
-//! for j in (0..num_items_per_thread).step_by(batch_size) {
-//!     let iter = (j..(j + batch_size)).map(|j| i * 100000 + j);
-//!     bag_ref.extend(iter);
-//! }
-//! ```
-//!
-//! <div id="section-performance-notes"></div>
-//!
-//! # D. Performance Notes
-//!
-//! ## How many times and how long we spin?
-//!
-//! Consider the `push` method, implementation of which is provided above. We will spin in the `std::cmp::Ordering::Greater => {}` branch. Fortunately, number of times we will spin is **deterministic**. It is exactly equal to the number of growth calls of the underlying pinned vector, and pinned vector implementations give a detailed control on this. For instance, assume that we will push a total of 15_000 elements concurrently to an empty bag.
-//!
-//! * Further assume we use the default `SplitVec<_, Doubling>` as the underlying pinned vector. Throughout the execution, we will allocate fragments of capacities [4, 8, 16, ..., 4096, 8192] which will lead to a total capacity of 16_380. In other words, we might possibly visit the `std::cmp::Ordering::Greater => {}` block in 12 points in time during the entire execution.
-//! * If we use a `SplitVec<_, Linear>` with constant fragment lengths of 1_024, we will allocate 15 equal capacity fragments, which will lead to a total capacity of 15_360. So looping might only happen 15 times. We can drop this number to 8 if we set constant fragment capacity to 2_048; i.e., we can control the frequency of allocations.
-//! * If we use the strict `FixedVec<_>`, we have to pre-allocate a safe amount and can never grow beyond this number. Therefore, there will never be any spinning.
-//!
-//! When we spin, we do not spin long because:
-//! * Pinned vectors do not change memory locations of already pushed elements. In other words, growths are copy-free.
-//! * We are only waiting for allocation of memory required for the growth with respect to the chosen growth strategy.
-//!
-//! ## False Sharing and How to Avoid
-//!
-//! [`ConcurrentBag::push`] method is implementation is simple, lock-free and efficient. However, we need to be aware of the potential [false sharing](https://en.wikipedia.org/wiki/False_sharing) risk which might lead to significant performance degradation. Fortunately, it is possible to avoid in many cases.
-//!
-//! ### When?
-//!
-//! Performance degradation due to false sharing might be observed when both of the following conditions hold:
-//! * **small data**: data to be pushed is small, the more elements fitting in a cache line the bigger the risk,
-//! * **little work**: multiple threads/cores are pushing to the concurrent bag with high frequency; i.e., very little or negligible work / time is required in between `push` calls.
-//!
-//! The example above fits this situation. Each thread only performs one multiplication and addition in between pushing elements, and the elements to be pushed are very small, just one `usize`.
-//!
-//! ### Why?
-//!
-//! * `ConcurrentBag` assigns unique positions to each value to be pushed. There is no *true* sharing among threads in the position level.
-//! * However, cache lines contain more than one position.
-//! * One thread updating a particular position invalidates the entire cache line on an other thread.
-//! * Threads end up frequently reloading cache lines instead of doing the actual work of writing elements to the bag.
-//! * This might lead to a significant performance degradation.
-//!
-//! Following two methods could be approached to deal with this problem.
-//!
-//! ### Solution-I: `extend` rather than `push`
-//!
-//! One very simple, effective and memory efficient solution to this problem is to use [`ConcurrentBag::extend`] rather than `push` in *small data & little work* situations.
-//!
-//! Assume that we will have 4 threads and each will push 1_024 elements. Instead of making 1_024 `push` calls from each thread, we can make one `extend` call from each. This would give the best performance. Further, it has zero buffer or memory cost:
-//! * it is important to note that the batch of 1_024 elements are not stored temporarily in another buffer,
-//! * there is no additional allocation,
-//! * `extend` does nothing more than reserving the position range for the thread by incrementing the atomic counter accordingly.
-//!
-//! However, we do not need to have such a perfect information about the number of elements to be pushed. Performance gains after reaching the cache line size are much lesser.
-//!
-//! For instance, consider the challenging super small element size case, where we are collecting `i32`s. We can already achieve a very high performance by simply `extend`ing the bag by batches of 16 elements.
-//!
-//! As the element size gets larger, required batch size to achieve a high performance gets smaller and smaller.
-//!
-//! Required change in the code from `push` to `extend` is not significant. The example above could be revised as follows to avoid the performance degrading of false sharing.
-//!
-//! ```rust
-//! use orx_concurrent_bag::*;
-//!
-//! let (num_threads, num_items_per_thread) = (4, 1_024);
-//! let bag = ConcurrentBag::new();
-//! let bag_ref = &bag;
-//! let batch_size = 16;
-//!
-//! std::thread::scope(|s| {
-//!     for i in 0..num_threads {
-//!         s.spawn(move || {
-//!             for j in (0..num_items_per_thread).step_by(batch_size) {
-//!                 let iter = (j..(j + batch_size)).map(|j| i * 1000 + j);
-//!                 bag_ref.extend(iter);
-//!             }
-//!         });
-//!     }
-//! });
-//! ```
-//!
-//! ### Solution-II: Padding
-//!
-//! Another common approach to deal with false sharing is to add padding (unused bytes) between elements. There exist wrappers which automatically adds cache padding, such as crossbeam's [`CachePadded`](https://docs.rs/crossbeam-utils/latest/crossbeam_utils/struct.CachePadded.html). In other words, instead of using a `ConcurrentBag<T>`, we can use `ConcurrentBag<CachePadded<T>>`. However, this solution leads to increased memory requirement.
-//!
-//! <div id="section-construction-and-conversions"></div>
-//!
-//! # E. `From` | `into_inner`
-//!
-//! `ConcurrentBag` can be constructed by wrapping any pinned vector; i.e., `ConcurrentBag<T>` implements `From<P: PinnedVec<T>>`.
-//! Likewise, a concurrent vector can be unwrapped without any cost to the underlying pinned vector with `into_inner` method.
+//! `ConcurrentBag` can be constructed by wrapping any pinned vector; i.e., `ConcurrentBag<T>` implements `From<P: PinnedVec<T>>`. Likewise, a concurrent vector can be unwrapped without any allocation to the underlying pinned vector with `into_inner` method.
 //!
 //! Further, there exist `with_` methods to directly construct the concurrent bag with common pinned vector implementations.
 //!
@@ -274,6 +81,146 @@
 //! let bag: ConcurrentBag<_> = split_vec.into();
 //! ```
 //!
+//! # Concurrent State and Properties
+//!
+//! The concurrent state is modeled simply by an atomic length. Combination of this state and `PinnedConcurrentCol` leads to the following properties:
+//! * Writing to a position of the collection does not block other writes, multiple writes can happen concurrently.
+//! * Each position is written exactly once.
+//! * ⟹ no write & write race condition exists.
+//! * Only one growth can happen at a given time.
+//! * Underlying pinned vector is always valid and can be taken out any time by `into_inner(self)`.
+//! * Reading is only possible after converting the bag into the underlying `PinnedVec`.
+//! * ⟹ no read & write race condition exists.
+//!
+//! <div id="section-benchmarks"></div>
+//!
+//! # Benchmarks
+//!
+//! ## Performance with `push`
+//!
+//! *You may find the details of the benchmarks at [benches/collect_with_push.rs](https://github.com/orxfun/orx-concurrent-bag/blob/main/benches/collect_with_push.rs).*
+//!
+//! In the experiment, `rayon`s parallel iterator and `ConcurrentBag`s `push` method are used to collect results from multiple threads.
+//!
+//! ```rust ignore
+//! // reserve and push one position at a time
+//! for j in 0..num_items_per_thread {
+//!     bag_ref.push(i * 1000 + j);
+//! }
+//! ```
+//!
+//! * We observe that rayon is significantly faster when the output is very small (`i32` in this experiment).
+//! * As the output gets larger and copies become costlier (`[i32; 32]` here), `ConcurrentBag::push` starts to outperform.
+//!
+//! The issue leading to poor performance in the *small data & little work* situation can be avoided by using `extend` method in such cases. You may see its impact in the succeeding subsections and related reasons in the <a href="#section-performance-notes">performance notes</a>.
+//!
+//! <img src="https://raw.githubusercontent.com/orxfun/orx-concurrent-bag/main/docs/img/bench_collect_with_push.PNG" alt="https://raw.githubusercontent.com/orxfun/orx-concurrent-bag/main/docs/img/bench_collect_with_push.PNG" />
+//!
+//! ## Performance with `extend`
+//!
+//! *You may find the details of the benchmarks at [benches/collect_with_extend.rs](https://github.com/orxfun/orx-concurrent-bag/blob/main/benches/collect_with_extend.rs).*
+//!
+//! The only difference in this follow up experiment is that we use `extend` rather than `push` with `ConcurrentBag`. The expectation is that this approach will solve the performance degradation due to false sharing in the *small data & little work* situation.
+//!
+//! ```rust ignore
+//! // reserve num_items_per_thread positions at a time
+//! // and then push as the iterator yields
+//! let iter = (0..num_items_per_thread).map(|j| i * 100000 + j);
+//! bag_ref.extend(iter);
+//! ```
+//!
+//! We now observe that `ConcurrentBag` is comparable to, if not faster than, rayon's parallel iterator in the small data case. The performance improvement is less dramatic but still significant in the larger output size case.
+//!
+//! <img src="https://raw.githubusercontent.com/orxfun/orx-concurrent-bag/main/docs/img/bench_collect_with_extend.PNG" alt="https://raw.githubusercontent.com/orxfun/orx-concurrent-bag/main/docs/img/bench_collect_with_extend.PNG" />
+//!
+//! Note that we do not need to have perfect information on the number of items to be pushed per thread to get the benefits of `extend`, we can simply `step_by`. Extending by `batch_size` elements will already prevent the dramatic performance degradation provided that `batch_size` elements exceed a cache line.
+//!
+//! ```rust ignore
+//! // reserve batch_size positions at a time
+//! // and then push as the iterator yields
+//! for j in (0..num_items_per_thread).step_by(batch_size) {
+//!     let iter = (j..(j + batch_size)).map(|j| i * 100000 + j);
+//!     bag_ref.extend(iter);
+//! }
+//! ```
+//!
+//! <div id="section-performance-notes"></div>
+//!
+//! ## Performance Notes
+//!
+//! ### How many times and how long we spin?
+//!
+//! There is only one waiting or spinning condition of the push and extend methods: whenever the underlying pinned vector needs to grow. Note that growth with pinned vector is copy free. Therefore, when it spins, all it waits for is the allocation. Further, note that number of times we will allocate, and hence spin, is deterministic.
+//!
+//! For instance, assume that we will push a total of 15_000 elements concurrently to an empty bag.
+//!
+//! * Further assume we use the default `SplitVec<_, Doubling>` as the underlying pinned vector. Throughout the execution, we will allocate fragments of capacities [4, 8, 16, ..., 4096, 8192] which will lead to a total capacity of 16_380. In other words, we will allocate exactly 12 times during the entire execution.
+//! * If we use a `SplitVec<_, Linear>` with constant fragment lengths of 1_024, we will allocate 15 equal capacity fragments.
+//! * If we use the strict `FixedVec<_>`, we have to pre-allocate a safe amount and can never grow beyond this number. Therefore, there will never be any spinning.
+//!
+//! ### False Sharing and How to Avoid
+//!
+//! [`ConcurrentBag::push`] method is implementation is simple, lock-free and efficient. However, we need to be aware of the potential [false sharing](https://en.wikipedia.org/wiki/False_sharing) risk which might lead to significant performance degradation. Fortunately, it is possible to avoid in many cases.
+//!
+//! #### When?
+//!
+//! Performance degradation due to false sharing might be observed specifically when both of the following conditions hold:
+//! * **small data**: data to be pushed is small, the more elements fitting in a cache line the bigger the risk,
+//! * **little work**: multiple threads/cores are pushing to the concurrent bag with high frequency; i.e., very little or negligible work / time is required in between `push` calls.
+//!
+//! The example above fits this situation. Each thread only performs one multiplication and addition in between pushing elements, and the elements to be pushed are very small, just one `usize`.
+//!
+//! #### Why?
+//!
+//! * `ConcurrentBag` assigns unique positions to each value to be pushed. There is no *true* sharing among threads in the position level.
+//! * However, cache lines contain more than one position.
+//! * One thread updating a particular position invalidates the entire cache line on an other thread.
+//! * Threads end up frequently reloading cache lines instead of doing the actual work of writing elements to the bag.
+//! * This might lead to a significant performance degradation.
+//!
+//! Following two methods could be approached to deal with this problem.
+//!
+//! #### Solution-I: `extend` rather than `push`
+//!
+//! One very simple, effective and memory efficient solution to this problem is to use [`ConcurrentBag::extend`] rather than `push` in *small data & little work* situations.
+//!
+//! Assume that we will have 4 threads and each will push 1_024 elements. Instead of making 1_024 `push` calls from each thread, we can make one `extend` call from each. This would give the best performance. Further, it has zero buffer or memory cost:
+//! * it is important to note that the batch of 1_024 elements are not stored temporarily in another buffer,
+//! * there is no additional allocation,
+//! * `extend` does nothing more than reserving the position range for the thread by incrementing the atomic counter accordingly.
+//!
+//! However, we do not need to have such a perfect information about the number of elements to be pushed. Performance gains after reaching the cache line size are much lesser.
+//!
+//! For instance, consider the challenging super small element size case, where we are collecting `i32`s. We can already achieve a very high performance by simply `extend`ing the bag by batches of 16 elements.
+//!
+//! As the element size gets larger, required batch size to achieve a high performance gets smaller and smaller.
+//!
+//! Required change in the code from `push` to `extend` is not significant. The example above could be revised as follows to avoid the performance degrading of false sharing.
+//!
+//! ```rust
+//! use orx_concurrent_bag::*;
+//!
+//! let (num_threads, num_items_per_thread) = (4, 1_024);
+//! let bag = ConcurrentBag::new();
+//! let bag_ref = &bag;
+//! let batch_size = 16;
+//!
+//! std::thread::scope(|s| {
+//!     for i in 0..num_threads {
+//!         s.spawn(move || {
+//!             for j in (0..num_items_per_thread).step_by(batch_size) {
+//!                 let iter = (j..(j + batch_size)).map(|j| i * 1000 + j);
+//!                 bag_ref.extend(iter);
+//!             }
+//!         });
+//!     }
+//! });
+//! ```
+//!
+//! #### Solution-II: Padding
+//!
+//! Another common approach to deal with false sharing is to add padding (unused bytes) between elements. There exist wrappers which automatically adds cache padding, such as crossbeam's [`CachePadded`](https://docs.rs/crossbeam-utils/latest/crossbeam_utils/struct.CachePadded.html). In other words, instead of using a `ConcurrentBag<T>`, we can use `ConcurrentBag<CachePadded<T>>`. However, this solution leads to increased memory requirement.
+//!
 //! # License
 //!
 //! This library is licensed under MIT license. See LICENSE for details.
@@ -292,7 +239,8 @@
 
 mod bag;
 mod common_traits;
-mod errors;
+mod new;
+mod state;
 
 /// Common relevant traits, structs, enums.
 pub mod prelude;

--- a/src/new.rs
+++ b/src/new.rs
@@ -1,0 +1,79 @@
+use crate::bag::ConcurrentBag;
+use orx_fixed_vec::{FixedVec, PinnedVec};
+use orx_split_vec::{Doubling, Linear, Recursive, SplitVec};
+
+impl<T> Default for ConcurrentBag<T, SplitVec<T, Doubling>> {
+    /// Creates a new concurrent bag by creating and wrapping up a new [`SplitVec<T, Doubling>`](https://docs.rs/orx-split-vec/latest/orx_split_vec/struct.Doubling.html) as the underlying storage.
+    fn default() -> Self {
+        Self::with_doubling_growth()
+    }
+}
+
+impl<T> ConcurrentBag<T, SplitVec<T, Doubling>> {
+    /// Creates a new concurrent bag by creating and wrapping up a new [`SplitVec<T, Doubling>`](https://docs.rs/orx-split-vec/latest/orx_split_vec/struct.Doubling.html) as the underlying storage.
+    pub fn new() -> Self {
+        Self::with_doubling_growth()
+    }
+
+    /// Creates a new concurrent bag by creating and wrapping up a new [`SplitVec<T, Doubling>`](https://docs.rs/orx-split-vec/latest/orx_split_vec/struct.Doubling.html) as the underlying storage.
+    pub fn with_doubling_growth() -> Self {
+        Self::new_from_pinned(SplitVec::with_doubling_growth_and_fragments_capacity(32))
+    }
+}
+
+impl<T> ConcurrentBag<T, SplitVec<T, Recursive>> {
+    /// Creates a new concurrent bag by creating and wrapping up a new [`SplitVec<T, Recursive>`](https://docs.rs/orx-split-vec/latest/orx_split_vec/struct.Recursive.html) as the underlying storage.
+    pub fn with_recursive_growth() -> Self {
+        Self::new_from_pinned(SplitVec::with_recursive_growth_and_fragments_capacity(32))
+    }
+}
+
+impl<T> ConcurrentBag<T, SplitVec<T, Linear>> {
+    /// Creates a new concurrent bag by creating and wrapping up a new [`SplitVec<T, Linear>`](https://docs.rs/orx-split-vec/latest/orx_split_vec/struct.Linear.html) as the underlying storage.
+    ///
+    /// * Each fragment of the split vector will have a capacity of  `2 ^ constant_fragment_capacity_exponent`.
+    /// * Further, fragments collection of the split vector will have a capacity of `fragments_capacity` on initialization.
+    ///
+    /// This leads to a [`orx_pinned_concurrent_col::PinnedConcurrentCol::maximum_capacity`] of `fragments_capacity * 2 ^ constant_fragment_capacity_exponent`.
+    ///
+    /// Whenever this capacity is not sufficient, fragments capacity can be increased by using the  [`orx_pinned_concurrent_col::PinnedConcurrentCol::reserve_maximum_capacity`] method.
+    pub fn with_linear_growth(
+        constant_fragment_capacity_exponent: usize,
+        fragments_capacity: usize,
+    ) -> Self {
+        Self::new_from_pinned(SplitVec::with_linear_growth_and_fragments_capacity(
+            constant_fragment_capacity_exponent,
+            fragments_capacity,
+        ))
+    }
+}
+
+impl<T> ConcurrentBag<T, FixedVec<T>> {
+    /// Creates a new concurrent bag by creating and wrapping up a new [`FixedVec<T>`]((https://docs.rs/orx-fixed-vec/latest/orx_fixed_vec/)) as the underlying storage.
+    ///
+    /// # Safety
+    ///
+    /// Note that a `FixedVec` cannot grow; i.e., it has a hard upper bound on the number of elements it can hold, which is the `fixed_capacity`.
+    ///
+    /// Pushing to the vector beyond this capacity leads to "out-of-capacity" error.
+    ///
+    /// This maximum capacity can be accessed by [`orx_pinned_concurrent_col::PinnedConcurrentCol::capacity`] or [`orx_pinned_concurrent_col::PinnedConcurrentCol::maximum_capacity`] methods.
+    pub fn with_fixed_capacity(fixed_capacity: usize) -> Self {
+        Self::new_from_pinned(FixedVec::new(fixed_capacity))
+    }
+}
+
+// from
+impl<T, P> From<P> for ConcurrentBag<T, P>
+where
+    P: PinnedVec<T>,
+{
+    /// `ConcurrentBag<T>` uses any `PinnedVec<T>` implementation as the underlying storage.
+    ///
+    /// Therefore, without a cost
+    /// * `ConcurrentBag<T>` can be constructed from any `PinnedVec<T>`, and
+    /// * the underlying `PinnedVec<T>` can be obtained by `ConcurrentBag::into_inner(self)` method.
+    fn from(pinned_vec: P) -> Self {
+        Self::new_from_pinned(pinned_vec)
+    }
+}

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -1,4 +1,5 @@
 pub use crate::bag::ConcurrentBag;
 pub use orx_fixed_vec::FixedVec;
+pub use orx_pinned_concurrent_col::PinnedConcurrentCol;
 pub use orx_pinned_vec::{CapacityState, PinnedVec, PinnedVecGrowthError};
 pub use orx_split_vec::{Doubling, Linear, Recursive, SplitVec};

--- a/src/state.rs
+++ b/src/state.rs
@@ -1,0 +1,76 @@
+use orx_pinned_concurrent_col::{ConcurrentState, PinnedConcurrentCol, WritePermit};
+use orx_pinned_vec::PinnedVec;
+use std::{
+    cmp::Ordering,
+    sync::atomic::{self, AtomicUsize},
+};
+
+#[derive(Debug)]
+pub struct ConcurrentBagState {
+    len: AtomicUsize,
+}
+
+impl ConcurrentState for ConcurrentBagState {
+    #[inline(always)]
+    fn zero_memory() -> bool {
+        false
+    }
+
+    fn new_for_pinned_vec<T, P: orx_fixed_vec::prelude::PinnedVec<T>>(pinned_vec: &P) -> Self {
+        Self {
+            len: pinned_vec.len().into(),
+        }
+    }
+
+    fn write_permit<T, P, S>(&self, col: &PinnedConcurrentCol<T, P, S>, idx: usize) -> WritePermit
+    where
+        P: PinnedVec<T>,
+        S: ConcurrentState,
+    {
+        let capacity = col.capacity();
+
+        match idx.cmp(&capacity) {
+            Ordering::Less => WritePermit::JustWrite,
+            Ordering::Equal => WritePermit::GrowThenWrite,
+            Ordering::Greater => WritePermit::Spin,
+        }
+    }
+
+    fn write_permit_n_items<T, P, S>(
+        &self,
+        col: &PinnedConcurrentCol<T, P, S>,
+        begin_idx: usize,
+        num_items: usize,
+    ) -> WritePermit
+    where
+        P: PinnedVec<T>,
+        S: ConcurrentState,
+    {
+        let capacity = col.capacity();
+        let last_idx = begin_idx + num_items - 1;
+
+        match (begin_idx.cmp(&capacity), last_idx.cmp(&capacity)) {
+            (_, std::cmp::Ordering::Less) => WritePermit::JustWrite,
+            (std::cmp::Ordering::Greater, _) => WritePermit::Spin,
+            _ => WritePermit::GrowThenWrite,
+        }
+    }
+
+    #[inline(always)]
+    fn release_growth_handle(&self) {}
+
+    #[inline(always)]
+    fn update_after_write(&self, _: usize, _: usize) {}
+}
+
+impl ConcurrentBagState {
+    #[inline(always)]
+    pub(crate) fn fetch_increment_len(&self, increment_by: usize) -> usize {
+        self.len.fetch_add(increment_by, atomic::Ordering::AcqRel)
+    }
+
+    #[inline(always)]
+    pub(crate) fn len(&self) -> usize {
+        self.len.load(atomic::Ordering::Relaxed)
+    }
+}

--- a/tests/concurrent_bag.rs
+++ b/tests/concurrent_bag.rs
@@ -1,0 +1,158 @@
+use orx_concurrent_bag::*;
+use std::{
+    collections::HashSet,
+    sync::{Arc, Mutex},
+};
+
+#[test]
+fn into_inner_from() {
+    let bag = ConcurrentBag::new();
+
+    bag.push('a');
+    bag.push('b');
+    bag.push('c');
+    bag.push('d');
+    assert_eq!(
+        vec!['a', 'b', 'c', 'd'],
+        unsafe { bag.iter() }.copied().collect::<Vec<_>>()
+    );
+
+    let mut split = bag.into_inner();
+    assert_eq!(
+        vec!['a', 'b', 'c', 'd'],
+        split.iter().copied().collect::<Vec<_>>()
+    );
+
+    split.push('e');
+    *split.get_mut(0).expect("exists") = 'x';
+
+    assert_eq!(
+        vec!['x', 'b', 'c', 'd', 'e'],
+        split.iter().copied().collect::<Vec<_>>()
+    );
+
+    let mut bag: ConcurrentBag<_> = split.into();
+    assert_eq!(
+        vec!['x', 'b', 'c', 'd', 'e'],
+        unsafe { bag.iter() }.copied().collect::<Vec<_>>()
+    );
+
+    bag.clear();
+    assert!(bag.is_empty());
+
+    let split = bag.into_inner();
+    assert!(split.is_empty());
+}
+
+#[test]
+fn ok_at_num_threads() {
+    use std::thread::available_parallelism;
+    let default_parallelism_approx = available_parallelism().expect("is-ok").get();
+
+    let num_threads = default_parallelism_approx;
+    let num_items_per_thread = 16384;
+
+    let bag = ConcurrentBag::new();
+    let bag_ref = &bag;
+    std::thread::scope(|s| {
+        for i in 0..num_threads {
+            s.spawn(move || {
+                for j in 0..num_items_per_thread {
+                    bag_ref.push((i * 100000 + j) as i32);
+                }
+            });
+        }
+    });
+
+    let pinned = bag.into_inner();
+    assert_eq!(pinned.len(), num_threads * num_items_per_thread);
+}
+
+#[test]
+fn push_indices() {
+    let num_threads = 4;
+    let num_items_per_thread = 16;
+
+    let indices_set = Arc::new(Mutex::new(HashSet::new()));
+
+    let bag = ConcurrentBag::new();
+    let bag_ref = &bag;
+    std::thread::scope(|s| {
+        for i in 0..num_threads {
+            let indices_set = indices_set.clone();
+            s.spawn(move || {
+                for j in 0..num_items_per_thread {
+                    let idx = bag_ref.push(i * 100000 + j);
+                    let mut set = indices_set.lock().expect("is ok");
+                    set.insert(idx);
+                }
+            });
+        }
+    });
+
+    let set = indices_set.lock().expect("is ok");
+    assert_eq!(set.len(), 4 * 16);
+    for i in 0..(4 * 16) {
+        assert!(set.contains(&i));
+    }
+}
+
+#[test]
+fn extend_indices() {
+    let num_threads = 4;
+    let num_items_per_thread = 16;
+
+    let indices_set = Arc::new(Mutex::new(HashSet::new()));
+
+    let bag = ConcurrentBag::new();
+    let bag_ref = &bag;
+    std::thread::scope(|s| {
+        for i in 0..num_threads {
+            let indices_set = indices_set.clone();
+            s.spawn(move || {
+                let iter = (0..num_items_per_thread).map(|j| i * 100000 + j);
+
+                let begin_idx = bag_ref.extend(iter);
+
+                let mut set = indices_set.lock().expect("is ok");
+                set.insert(begin_idx);
+            });
+        }
+    });
+
+    let set = indices_set.lock().expect("is ok");
+    assert_eq!(set.len(), num_threads);
+    for i in 0..num_threads {
+        assert!(set.contains(&(i * num_items_per_thread)));
+    }
+}
+
+#[test]
+fn extend_n_items_indices() {
+    let num_threads = 4;
+    let num_items_per_thread = 16;
+
+    let indices_set = Arc::new(Mutex::new(HashSet::new()));
+
+    let bag = ConcurrentBag::new();
+    let bag_ref = &bag;
+    std::thread::scope(|s| {
+        for i in 0..num_threads {
+            let indices_set = indices_set.clone();
+            s.spawn(move || {
+                let iter = (0..num_items_per_thread).map(|j| i * 100000 + j);
+
+                let begin_idx = unsafe { bag_ref.extend_n_items(iter, num_items_per_thread) };
+
+                let mut set = indices_set.lock().expect("is ok");
+                set.insert(begin_idx);
+            });
+        }
+    });
+
+    let set = indices_set.lock().expect("is ok");
+    assert_eq!(set.len(), num_threads);
+    for i in 0..num_threads {
+        assert!(set.contains(&(i * num_items_per_thread)));
+    }
+}

--- a/tests/new.rs
+++ b/tests/new.rs
@@ -1,0 +1,36 @@
+use orx_concurrent_bag::*;
+
+#[test]
+fn new_len_empty_clear() {
+    fn test<P: PinnedVec<char>>(bag: ConcurrentBag<char, P>) {
+        assert!(!bag.zeroes_memory_on_allocation());
+
+        let mut bag = bag;
+
+        assert!(bag.is_empty());
+        assert_eq!(0, bag.len());
+
+        bag.push('a');
+
+        assert!(!bag.is_empty());
+        assert_eq!(1, bag.len());
+
+        bag.push('b');
+        bag.push('c');
+        bag.push('d');
+
+        assert!(!bag.is_empty());
+        assert_eq!(4, bag.len());
+
+        bag.clear();
+        assert!(bag.is_empty());
+        assert_eq!(0, bag.len());
+    }
+
+    test(ConcurrentBag::new());
+    test(ConcurrentBag::default());
+    test(ConcurrentBag::with_doubling_growth());
+    test(ConcurrentBag::with_linear_growth(2, 8));
+    test(ConcurrentBag::with_linear_growth(4, 8));
+    test(ConcurrentBag::with_fixed_capacity(64));
+}

--- a/tests/pinned_concurrent_col.rs
+++ b/tests/pinned_concurrent_col.rs
@@ -1,0 +1,179 @@
+use orx_concurrent_bag::*;
+use std::time::Duration;
+
+#[test]
+fn capacity() {
+    let mut split: SplitVec<_, Doubling> = (0..4).collect();
+    split.concurrent_reserve(5).expect("is-ok");
+    let bag: ConcurrentBag<_, _> = split.into();
+    assert_eq!(bag.capacity(), 4);
+    bag.push(42);
+    assert_eq!(bag.capacity(), 12);
+
+    let mut split: SplitVec<_, Recursive> = (0..4).collect();
+    split.concurrent_reserve(5).expect("is-ok");
+    let bag: ConcurrentBag<_, _> = split.into();
+    assert_eq!(bag.capacity(), 4);
+    bag.push(42);
+    assert_eq!(bag.capacity(), 12);
+
+    let mut split: SplitVec<_, Linear> = SplitVec::with_linear_growth(2);
+    split.extend_from_slice(&[0, 1, 2, 3]);
+    split.concurrent_reserve(5).expect("is-ok");
+    let bag: ConcurrentBag<_, _> = split.into();
+    assert_eq!(bag.capacity(), 4);
+    bag.push(42);
+    assert_eq!(bag.capacity(), 8);
+
+    let mut fixed: FixedVec<_> = FixedVec::new(5);
+    fixed.extend_from_slice(&[0, 1, 2, 3]);
+    let bag: ConcurrentBag<_, _> = fixed.into();
+    assert_eq!(bag.capacity(), 5);
+    bag.push(42);
+    assert_eq!(bag.capacity(), 5);
+}
+
+#[test]
+#[should_panic]
+fn exceeding_fixed_capacity_panics() {
+    let mut fixed: FixedVec<_> = FixedVec::new(5);
+    fixed.extend_from_slice(&[0, 1, 2, 3]);
+    let bag: ConcurrentBag<_, _> = fixed.into();
+    assert_eq!(bag.capacity(), 5);
+    bag.push(42);
+    bag.push(7);
+}
+
+#[test]
+#[should_panic]
+fn exceeding_fixed_capacity_panics_concurrently() {
+    let bag = ConcurrentBag::with_fixed_capacity(10);
+    let bag_ref = &bag;
+    std::thread::scope(|s| {
+        for _ in 0..4 {
+            s.spawn(move || {
+                for _ in 0..3 {
+                    // in total there will be 4*3 = 12 pushes
+                    bag_ref.push(42);
+                }
+            });
+        }
+    });
+}
+
+#[test]
+fn get() {
+    // record measurements in (assume) random intervals
+    let measurements = ConcurrentBag::<i32>::new();
+    let rf_measurements = &measurements;
+
+    // collect sum of measurements every 50 milliseconds
+    let sums = ConcurrentBag::new();
+    let rf_sums = &sums;
+
+    // collect average of measurements every 50 milliseconds
+    let averages = ConcurrentBag::new();
+    let rf_averages = &averages;
+
+    std::thread::scope(|s| {
+        s.spawn(move || {
+            for i in 0..100 {
+                std::thread::sleep(Duration::from_millis(i % 5));
+                rf_measurements.push(i as i32);
+            }
+        });
+
+        s.spawn(move || {
+            for _ in 0..10 {
+                let mut sum = 0;
+                for i in 0..rf_measurements.len() {
+                    sum += unsafe { rf_measurements.get(i) }.copied().unwrap_or(0);
+                }
+                rf_sums.push(sum);
+                std::thread::sleep(Duration::from_millis(50));
+            }
+        });
+
+        s.spawn(move || {
+            for _ in 0..10 {
+                let count = rf_measurements.len();
+                if count == 0 {
+                    rf_averages.push(0.0);
+                } else {
+                    let mut sum = 0;
+                    for i in 0..rf_measurements.len() {
+                        sum += unsafe { rf_measurements.get(i) }.copied().unwrap_or(0);
+                    }
+                    let average = sum as f32 / count as f32;
+                    rf_averages.push(average);
+                }
+                std::thread::sleep(Duration::from_millis(50));
+            }
+        });
+    });
+
+    assert_eq!(measurements.len(), 100);
+    assert_eq!(sums.len(), 10);
+    assert_eq!(averages.len(), 10);
+}
+
+#[test]
+fn iter() {
+    let mut bag = ConcurrentBag::new();
+
+    assert_eq!(0, unsafe { bag.iter() }.count());
+
+    bag.push('a');
+
+    assert_eq!(
+        vec!['a'],
+        unsafe { bag.iter() }.copied().collect::<Vec<_>>()
+    );
+
+    bag.push('b');
+    bag.push('c');
+    bag.push('d');
+
+    assert_eq!(
+        vec!['a', 'b', 'c', 'd'],
+        unsafe { bag.iter() }.copied().collect::<Vec<_>>()
+    );
+
+    bag.clear();
+    assert_eq!(0, unsafe { bag.iter() }.count());
+}
+
+#[test]
+fn reserve_maximum_capacity() {
+    // SplitVec<_, Doubling>
+    let bag: ConcurrentBag<char> = ConcurrentBag::new();
+    assert_eq!(bag.capacity(), 4); // only allocates the first fragment of 4
+    assert_eq!(bag.maximum_capacity(), 17_179_869_180); // it can grow safely & exponentially
+
+    let bag: ConcurrentBag<char, _> = ConcurrentBag::with_doubling_growth();
+    assert_eq!(bag.capacity(), 4);
+    assert_eq!(bag.maximum_capacity(), 17_179_869_180);
+
+    // SplitVec<_, Linear>
+    let mut bag: ConcurrentBag<char, _> = ConcurrentBag::with_linear_growth(10, 20);
+    assert_eq!(bag.capacity(), 2usize.pow(10)); // only allocates first fragment of 1024
+    assert_eq!(bag.maximum_capacity(), 2usize.pow(10) * 20); // it can concurrently allocate 19 more
+
+    // SplitVec<_, Linear> -> reserve_maximum_capacity
+    let result = bag.reserve_maximum_capacity(2usize.pow(10) * 30);
+    assert!(result.is_ok());
+    assert!(result.expect("is-ok") >= 2usize.pow(10) * 30);
+
+    // actually no new allocation yet; precisely additional memory for 10 pairs of pointers is used
+    assert_eq!(bag.capacity(), 2usize.pow(10)); // first fragment capacity
+
+    assert!(bag.maximum_capacity() >= 2usize.pow(10) * 30); // now it can safely reach 2^10 * 30
+
+    // FixedVec<_>: pre-allocated, exact and strict
+    let mut bag: ConcurrentBag<char, _> = ConcurrentBag::with_fixed_capacity(42);
+    assert_eq!(bag.capacity(), 42);
+    assert_eq!(bag.maximum_capacity(), 42);
+
+    let result = bag.reserve_maximum_capacity(43);
+    assert!(result.is_err());
+}


### PR DESCRIPTION
`ConcurrentBag` now is only a wrapper around a `PinnedConcurrentCol` with a specific `ConcurrentState` implementation.
* `State` defines and implements the unique properties of the concurrent bag.
* `ConcurrentBag` implements `Deref` and `DerefMut` for `PinnedConcurrentCol`.
* Documentation is revised.
* Benchmarks are repeated, performance has not changed (as expected).