### PR TITLE
pinned-vec-support-for-concurrency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "orx-concurrent-bag"
-version = "1.16.0"
+version = "2.0.0"
 edition = "2021"
 authors = ["orxfun <orx.ugur.arikan@gmail.com>"]
 description = "An efficient, convenient and lightweight grow-only concurrent data structure allowing high performance concurrent collection."
@@ -10,10 +10,11 @@ keywords = ["concurrency", "bag", "data-structures", "atomic", "lock-free"]
 categories = ["data-structures", "concurrency", "rust-patterns"]
 
 [dependencies]
-orx-fixed-vec = "2.12"
-orx-pinned-concurrent-col = "1.6"
-orx-pinned-vec = "2.12"
-orx-split-vec = "2.14"
+orx-pseudo-default = "1.0"
+orx-fixed-vec = "3.0"
+orx-pinned-vec = "3.0"
+orx-split-vec = "3.0"
+orx-pinned-concurrent-col = "2.0"
 
 [dev-dependencies]
 criterion = "0.5.1"

--- a/src/common_traits/debug.rs
+++ b/src/common_traits/debug.rs
@@ -1,33 +1,11 @@
 use crate::ConcurrentBag;
-use orx_fixed_vec::PinnedVec;
+use orx_pinned_vec::IntoConcurrentPinnedVec;
 use std::fmt::Debug;
 
-impl<T: Debug, P: PinnedVec<T>> Debug for ConcurrentBag<T, P> {
+impl<T: Debug, P: IntoConcurrentPinnedVec<T>> Debug for ConcurrentBag<T, P> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("ConcurrentBag")
             .field("core", self.core())
             .finish()
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn debug() {
-        let bag = ConcurrentBag::new();
-
-        bag.push('a');
-        bag.push('b');
-        bag.push('c');
-        bag.push('d');
-        bag.push('e');
-
-        let str = format!("{:?}", bag);
-        assert_eq!(
-            str,
-            "ConcurrentBag { core: PinnedConcurrentCol { pinned_vec: \"PinnedVec\", state: ConcurrentBagState { len: 5 }, capacity: CapacityState { capacity: 12, maximum_capacity: 17179869180 } } }"
-        );
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -240,5 +240,7 @@ pub mod prelude;
 
 pub use bag::ConcurrentBag;
 pub use orx_fixed_vec::FixedVec;
-pub use orx_pinned_vec::{CapacityState, PinnedVec, PinnedVecGrowthError};
-pub use orx_split_vec::{Doubling, Linear, Recursive, SplitVec};
+pub use orx_pinned_vec::{
+    ConcurrentPinnedVec, IntoConcurrentPinnedVec, PinnedVec, PinnedVecGrowthError,
+};
+pub use orx_split_vec::{Doubling, Linear, SplitVec};

--- a/src/new.rs
+++ b/src/new.rs
@@ -1,6 +1,7 @@
 use crate::bag::ConcurrentBag;
-use orx_fixed_vec::{FixedVec, PinnedVec};
-use orx_split_vec::{Doubling, Linear, Recursive, SplitVec};
+use orx_fixed_vec::FixedVec;
+use orx_pinned_vec::IntoConcurrentPinnedVec;
+use orx_split_vec::{Doubling, Linear, SplitVec};
 
 impl<T> Default for ConcurrentBag<T, SplitVec<T, Doubling>> {
     /// Creates a new concurrent bag by creating and wrapping up a new [`SplitVec<T, Doubling>`](https://docs.rs/orx-split-vec/latest/orx_split_vec/struct.Doubling.html) as the underlying storage.
@@ -18,13 +19,6 @@ impl<T> ConcurrentBag<T, SplitVec<T, Doubling>> {
     /// Creates a new concurrent bag by creating and wrapping up a new [`SplitVec<T, Doubling>`](https://docs.rs/orx-split-vec/latest/orx_split_vec/struct.Doubling.html) as the underlying storage.
     pub fn with_doubling_growth() -> Self {
         Self::new_from_pinned(SplitVec::with_doubling_growth_and_fragments_capacity(32))
-    }
-}
-
-impl<T> ConcurrentBag<T, SplitVec<T, Recursive>> {
-    /// Creates a new concurrent bag by creating and wrapping up a new [`SplitVec<T, Recursive>`](https://docs.rs/orx-split-vec/latest/orx_split_vec/struct.Recursive.html) as the underlying storage.
-    pub fn with_recursive_growth() -> Self {
-        Self::new_from_pinned(SplitVec::with_recursive_growth_and_fragments_capacity(32))
     }
 }
 
@@ -63,17 +57,11 @@ impl<T> ConcurrentBag<T, FixedVec<T>> {
     }
 }
 
-// from
 impl<T, P> From<P> for ConcurrentBag<T, P>
 where
-    P: PinnedVec<T>,
+    P: IntoConcurrentPinnedVec<T>,
 {
-    /// `ConcurrentBag<T>` uses any `PinnedVec<T>` implementation as the underlying storage.
-    ///
-    /// Therefore, without a cost
-    /// * `ConcurrentBag<T>` can be constructed from any `PinnedVec<T>`, and
-    /// * the underlying `PinnedVec<T>` can be obtained by `ConcurrentBag::into_inner(self)` method.
-    fn from(pinned_vec: P) -> Self {
-        Self::new_from_pinned(pinned_vec)
+    fn from(value: P) -> Self {
+        Self::new_from_pinned(value)
     }
 }

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -1,5 +1,7 @@
 pub use crate::bag::ConcurrentBag;
 pub use orx_fixed_vec::FixedVec;
 pub use orx_pinned_concurrent_col::PinnedConcurrentCol;
-pub use orx_pinned_vec::{CapacityState, PinnedVec, PinnedVecGrowthError};
-pub use orx_split_vec::{Doubling, Linear, Recursive, SplitVec};
+pub use orx_pinned_vec::{
+    ConcurrentPinnedVec, IntoConcurrentPinnedVec, PinnedVec, PinnedVecGrowthError,
+};
+pub use orx_split_vec::{Doubling, Linear, SplitVec};

--- a/tests/concurrent_bag.rs
+++ b/tests/concurrent_bag.rs
@@ -1,41 +1,53 @@
 use orx_concurrent_bag::*;
+use orx_pinned_vec::IntoConcurrentPinnedVec;
 use std::{
     collections::HashSet,
     sync::{Arc, Mutex},
 };
+use test_case::test_matrix;
 
-#[test]
-fn into_inner_from() {
-    let bag = ConcurrentBag::new();
+#[test_matrix([
+    FixedVec::new(2132),
+    SplitVec::with_doubling_growth_and_fragments_capacity(16),
+    SplitVec::with_linear_growth_and_fragments_capacity(10, 33)
+])]
+fn into_inner_from<P: IntoConcurrentPinnedVec<char> + Clone>(pinned: P) {
+    let elements = vec!['a', 'b', 'c', 'd', 'e'];
 
-    bag.push('a');
-    bag.push('b');
-    bag.push('c');
-    bag.push('d');
-    assert_eq!(
-        vec!['a', 'b', 'c', 'd'],
-        unsafe { bag.iter() }.copied().collect::<Vec<_>>()
-    );
+    let bag = ConcurrentBag::from(pinned);
 
-    let mut split = bag.into_inner();
-    assert_eq!(
-        vec!['a', 'b', 'c', 'd'],
-        split.iter().copied().collect::<Vec<_>>()
-    );
-
-    split.push('e');
-    *split.get_mut(0).expect("exists") = 'x';
+    for c in &elements {
+        bag.push(*c);
+    }
 
     assert_eq!(
-        vec!['x', 'b', 'c', 'd', 'e'],
-        split.iter().copied().collect::<Vec<_>>()
+        &elements,
+        &unsafe { bag.iter() }.copied().collect::<Vec<_>>()
     );
+    for (i, c) in elements.iter().enumerate() {
+        assert_eq!(Some(c), unsafe { bag.get(i) });
+    }
 
-    let mut bag: ConcurrentBag<_> = split.into();
+    let mut pinned = bag.into_inner();
+    let vec: Vec<_> = pinned.iter().copied().collect();
+    assert_eq!(&elements, &vec);
+
+    pinned.push('f');
+    *pinned.get_mut(0).expect("exists") = 'x';
+
+    let elements = vec!['x', 'b', 'c', 'd', 'e', 'f'];
+
+    let vec: Vec<_> = pinned.iter().copied().collect();
+    assert_eq!(&elements, &vec);
+
+    let mut bag = ConcurrentBag::from(pinned);
     assert_eq!(
-        vec!['x', 'b', 'c', 'd', 'e'],
-        unsafe { bag.iter() }.copied().collect::<Vec<_>>()
+        &elements,
+        &unsafe { bag.iter() }.copied().collect::<Vec<_>>()
     );
+    for (i, c) in elements.iter().enumerate() {
+        assert_eq!(Some(c), unsafe { bag.get(i) });
+    }
 
     bag.clear();
     assert!(bag.is_empty());
@@ -44,21 +56,22 @@ fn into_inner_from() {
     assert!(split.is_empty());
 }
 
-#[test]
-fn ok_at_num_threads() {
-    use std::thread::available_parallelism;
-    let default_parallelism_approx = available_parallelism().expect("is-ok").get();
+#[test_matrix([
+    FixedVec::new(5000),
+    SplitVec::with_doubling_growth_and_fragments_capacity(16),
+    SplitVec::with_linear_growth_and_fragments_capacity(10, 33)
+])]
+fn ok_at_num_threads<P: IntoConcurrentPinnedVec<String> + Clone>(pinned: P) {
+    let num_threads = 8;
+    let num_items_per_thread = 500;
 
-    let num_threads = default_parallelism_approx;
-    let num_items_per_thread = 16384;
-
-    let bag = ConcurrentBag::new();
+    let bag = ConcurrentBag::from(pinned);
     let bag_ref = &bag;
     std::thread::scope(|s| {
         for i in 0..num_threads {
             s.spawn(move || {
                 for j in 0..num_items_per_thread {
-                    bag_ref.push((i * 100000 + j) as i32);
+                    bag_ref.push((i * 100000 + j).to_string());
                 }
             });
         }
@@ -68,21 +81,25 @@ fn ok_at_num_threads() {
     assert_eq!(pinned.len(), num_threads * num_items_per_thread);
 }
 
-#[test]
-fn push_indices() {
+#[test_matrix([
+    FixedVec::new(333),
+    SplitVec::with_doubling_growth_and_fragments_capacity(16),
+    SplitVec::with_linear_growth_and_fragments_capacity(10, 33)
+])]
+fn push_indices<P: IntoConcurrentPinnedVec<String> + Clone>(pinned: P) {
     let num_threads = 4;
-    let num_items_per_thread = 16;
+    let num_items_per_thread = 64;
 
     let indices_set = Arc::new(Mutex::new(HashSet::new()));
 
-    let bag = ConcurrentBag::new();
+    let bag = ConcurrentBag::from(pinned);
     let bag_ref = &bag;
     std::thread::scope(|s| {
         for i in 0..num_threads {
             let indices_set = indices_set.clone();
             s.spawn(move || {
                 for j in 0..num_items_per_thread {
-                    let idx = bag_ref.push(i * 100000 + j);
+                    let idx = bag_ref.push((i * 100000 + j).to_string());
                     let mut set = indices_set.lock().expect("is ok");
                     set.insert(idx);
                 }
@@ -91,26 +108,30 @@ fn push_indices() {
     });
 
     let set = indices_set.lock().expect("is ok");
-    assert_eq!(set.len(), 4 * 16);
-    for i in 0..(4 * 16) {
+    assert_eq!(set.len(), num_threads * num_items_per_thread);
+    for i in 0..(num_threads * num_items_per_thread) {
         assert!(set.contains(&i));
     }
 }
 
-#[test]
-fn extend_indices() {
+#[test_matrix([
+    FixedVec::new(733),
+    SplitVec::with_doubling_growth_and_fragments_capacity(16),
+    SplitVec::with_linear_growth_and_fragments_capacity(10, 33)
+])]
+fn extend_indices<P: IntoConcurrentPinnedVec<String> + Clone>(pinned: P) {
     let num_threads = 4;
-    let num_items_per_thread = 16;
+    let num_items_per_thread = 128;
 
     let indices_set = Arc::new(Mutex::new(HashSet::new()));
 
-    let bag = ConcurrentBag::new();
+    let bag = ConcurrentBag::from(pinned);
     let bag_ref = &bag;
     std::thread::scope(|s| {
         for i in 0..num_threads {
             let indices_set = indices_set.clone();
             s.spawn(move || {
-                let iter = (0..num_items_per_thread).map(|j| i * 100000 + j);
+                let iter = (0..num_items_per_thread).map(|j| (i * 100000 + j).to_string());
 
                 let begin_idx = bag_ref.extend(iter);
 
@@ -127,20 +148,24 @@ fn extend_indices() {
     }
 }
 
-#[test]
-fn extend_n_items_indices() {
+#[test_matrix([
+    FixedVec::new(733),
+    SplitVec::with_doubling_growth_and_fragments_capacity(16),
+    SplitVec::with_linear_growth_and_fragments_capacity(10, 33)
+])]
+fn extend_n_items_indices<P: IntoConcurrentPinnedVec<String> + Clone>(pinned: P) {
     let num_threads = 4;
-    let num_items_per_thread = 16;
+    let num_items_per_thread = 128;
 
     let indices_set = Arc::new(Mutex::new(HashSet::new()));
 
-    let bag = ConcurrentBag::new();
+    let bag = ConcurrentBag::from(pinned);
     let bag_ref = &bag;
     std::thread::scope(|s| {
         for i in 0..num_threads {
             let indices_set = indices_set.clone();
             s.spawn(move || {
-                let iter = (0..num_items_per_thread).map(|j| i * 100000 + j);
+                let iter = (0..num_items_per_thread).map(|j| (i * 100000 + j).to_string());
 
                 let begin_idx = unsafe { bag_ref.extend_n_items(iter, num_items_per_thread) };
 

--- a/tests/drop.rs
+++ b/tests/drop.rs
@@ -1,18 +1,18 @@
 use orx_concurrent_bag::*;
+use orx_pinned_vec::IntoConcurrentPinnedVec;
 use test_case::test_matrix;
 
-const NUM_RERUNS: usize = 1024;
+const NUM_RERUNS: usize = 1;
 
 #[test_matrix(
     [
         FixedVec::new(100000),
         SplitVec::with_doubling_growth_and_fragments_capacity(32),
-        SplitVec::with_recursive_growth_and_fragments_capacity(32),
         SplitVec::with_linear_growth_and_fragments_capacity(10, 64),
     ],
-    [124, 348, 1024, 2587, 42578]
+    [124, 348, 1024, 2587]
 )]
-fn dropped_as_bag<P: PinnedVec<String> + Clone>(pinned_vec: P, len: usize) {
+fn dropped_as_bag<P: IntoConcurrentPinnedVec<String> + Clone>(pinned_vec: P, len: usize) {
     for _ in 0..NUM_RERUNS {
         let num_threads = 4;
         let num_items_per_thread = len / num_threads;
@@ -27,12 +27,11 @@ fn dropped_as_bag<P: PinnedVec<String> + Clone>(pinned_vec: P, len: usize) {
     [
         FixedVec::new(100000),
         SplitVec::with_doubling_growth_and_fragments_capacity(32),
-        SplitVec::with_recursive_growth_and_fragments_capacity(32),
         SplitVec::with_linear_growth_and_fragments_capacity(10, 64),
     ],
-    [124, 348, 1024, 2587, 42578]
+    [124, 348, 1024, 2587]
 )]
-fn dropped_after_into_inner<P: PinnedVec<String> + Clone>(pinned_vec: P, len: usize) {
+fn dropped_after_into_inner<P: IntoConcurrentPinnedVec<String> + Clone>(pinned_vec: P, len: usize) {
     for _ in 0..NUM_RERUNS {
         let num_threads = 4;
         let num_items_per_thread = len / num_threads;
@@ -44,7 +43,10 @@ fn dropped_after_into_inner<P: PinnedVec<String> + Clone>(pinned_vec: P, len: us
     }
 }
 
-fn fill_bag<P: PinnedVec<String>>(pinned_vec: P, len: usize) -> ConcurrentBag<String, P> {
+fn fill_bag<P: IntoConcurrentPinnedVec<String>>(
+    pinned_vec: P,
+    len: usize,
+) -> ConcurrentBag<String, P> {
     let num_threads = 4;
     let num_items_per_thread = len / num_threads;
 

--- a/tests/extend.rs
+++ b/tests/extend.rs
@@ -1,11 +1,11 @@
 use orx_concurrent_bag::*;
 use orx_fixed_vec::FixedVec;
-use orx_pinned_vec::PinnedVec;
+use orx_pinned_vec::IntoConcurrentPinnedVec;
 use orx_split_vec::SplitVec;
-use std::{sync::Arc, thread, time::Duration};
+use std::time::Duration;
 use test_case::test_case;
 
-const NUM_RERUNS: usize = 4;
+const NUM_RERUNS: usize = 1;
 
 const EXHAUSTIVE_INPUTS: [(usize, usize); 15] = [
     (1, 64),
@@ -37,35 +37,7 @@ const FAST_INPUTS: [(usize, usize); 9] = [
     (8, 256),
 ];
 
-fn run_with_arc<P: PinnedVec<i32> + Clone + 'static>(
-    pinned: P,
-    num_threads: usize,
-    num_items_per_thread: usize,
-    do_sleep: bool,
-) {
-    for _ in 0..NUM_RERUNS {
-        let bag: ConcurrentBag<_, _> = pinned.clone().into();
-        let bag = Arc::new(bag);
-        let mut thread_vec: Vec<thread::JoinHandle<()>> = Vec::new();
-
-        for i in 0..num_threads {
-            let bag = bag.clone();
-            thread_vec.push(thread::spawn(move || {
-                sleep(do_sleep, i);
-                let into_iter = (0..num_items_per_thread).map(|j| (i * 100000 + j) as i32);
-                bag.extend(into_iter);
-            }));
-        }
-
-        for handle in thread_vec {
-            handle.join().unwrap();
-        }
-
-        assert_result(num_threads, num_items_per_thread, &bag);
-    }
-}
-
-fn run_with_scope<P: PinnedVec<i32> + Clone + 'static>(
+fn run_with_scope<P: IntoConcurrentPinnedVec<i32> + Clone + 'static>(
     pinned: P,
     num_threads: usize,
     num_items_per_thread: usize,
@@ -84,36 +56,37 @@ fn run_with_scope<P: PinnedVec<i32> + Clone + 'static>(
             }
         });
 
-        assert_result(num_threads, num_items_per_thread, &bag);
+        assert_result(num_threads, num_items_per_thread, bag.into_inner());
     }
 }
 
-fn run_test<P: PinnedVec<i32> + Clone + 'static>(pinned: P, inputs: &[(usize, usize)]) {
+fn run_test<P: IntoConcurrentPinnedVec<i32> + Clone + 'static>(
+    pinned: P,
+    inputs: &[(usize, usize)],
+) {
     for sleep in [false, true] {
         for (num_threads, num_items_per_thread) in inputs.iter() {
-            run_with_arc(pinned.clone(), *num_threads, *num_items_per_thread, sleep);
             run_with_scope(pinned.clone(), *num_threads, *num_items_per_thread, sleep);
         }
     }
 }
 
-#[test_case(FixedVec::new(524288))]
-#[test_case(SplitVec::with_doubling_growth_and_fragments_capacity(32))]
-#[test_case(SplitVec::with_recursive_growth_and_fragments_capacity(32))]
-#[test_case(SplitVec::with_linear_growth_and_fragments_capacity(6, 8192))]
-#[test_case(SplitVec::with_linear_growth_and_fragments_capacity(10, 512))]
-#[test_case(SplitVec::with_linear_growth_and_fragments_capacity(14, 32))]
-fn exhaustive<P: PinnedVec<i32> + Clone + 'static>(pinned: P) {
+// #[test_case(FixedVec::new(524288))]
+// #[test_case(SplitVec::with_doubling_growth_and_fragments_capacity(32))]
+// #[test_case(SplitVec::with_linear_growth_and_fragments_capacity(6, 8192))]
+// #[test_case(SplitVec::with_linear_growth_and_fragments_capacity(10, 512))]
+// #[test_case(SplitVec::with_linear_growth_and_fragments_capacity(14, 32))]
+#[allow(dead_code)]
+fn exhaustive<P: IntoConcurrentPinnedVec<i32> + Clone + 'static>(pinned: P) {
     run_test(pinned, &EXHAUSTIVE_INPUTS)
 }
 
 #[test_case(FixedVec::new(3000))]
 #[test_case(SplitVec::with_doubling_growth_and_fragments_capacity(32))]
-#[test_case(SplitVec::with_recursive_growth_and_fragments_capacity(32))]
 #[test_case(SplitVec::with_linear_growth_and_fragments_capacity(6, 40))]
 #[test_case(SplitVec::with_linear_growth_and_fragments_capacity(10, 10))]
 #[test_case(SplitVec::with_linear_growth_and_fragments_capacity(14, 10))]
-fn fast<P: PinnedVec<i32> + Clone + 'static>(pinned: P) {
+fn fast<P: IntoConcurrentPinnedVec<i32> + Clone + 'static>(pinned: P) {
     run_test(pinned, &FAST_INPUTS)
 }
 
@@ -126,12 +99,12 @@ fn expected_result(num_threads: usize, num_items_per_thread: usize) -> Vec<i32> 
     expected
 }
 
-fn assert_result<P: PinnedVec<i32>>(
+fn assert_result<P: IntoConcurrentPinnedVec<i32>>(
     num_threads: usize,
     num_items_per_thread: usize,
-    bag: &ConcurrentBag<i32, P>,
+    vec_from_bag: P,
 ) {
-    let mut vec_from_bag: Vec<_> = unsafe { bag.iter() }.copied().collect();
+    let mut vec_from_bag: Vec<_> = vec_from_bag.iter().copied().collect();
     vec_from_bag.sort();
 
     let expected = expected_result(num_threads, num_items_per_thread);

--- a/tests/new.rs
+++ b/tests/new.rs
@@ -1,10 +1,9 @@
 use orx_concurrent_bag::*;
+use orx_pinned_vec::IntoConcurrentPinnedVec;
 
 #[test]
 fn new_len_empty_clear() {
-    fn test<P: PinnedVec<char>>(bag: ConcurrentBag<char, P>) {
-        assert!(!bag.zeroes_memory_on_allocation());
-
+    fn test<P: IntoConcurrentPinnedVec<char>>(bag: ConcurrentBag<char, P>) {
         let mut bag = bag;
 
         assert!(bag.is_empty());
@@ -18,9 +17,10 @@ fn new_len_empty_clear() {
         bag.push('b');
         bag.push('c');
         bag.push('d');
+        bag.push('e');
 
         assert!(!bag.is_empty());
-        assert_eq!(4, bag.len());
+        assert_eq!(5, bag.len());
 
         bag.clear();
         assert!(bag.is_empty());

--- a/tests/pinned_concurrent_col.rs
+++ b/tests/pinned_concurrent_col.rs
@@ -1,16 +1,11 @@
 use orx_concurrent_bag::*;
+use orx_pinned_vec::IntoConcurrentPinnedVec;
 use std::time::Duration;
+use test_case::test_matrix;
 
 #[test]
 fn capacity() {
     let mut split: SplitVec<_, Doubling> = (0..4).collect();
-    split.concurrent_reserve(5).expect("is-ok");
-    let bag: ConcurrentBag<_, _> = split.into();
-    assert_eq!(bag.capacity(), 4);
-    bag.push(42);
-    assert_eq!(bag.capacity(), 12);
-
-    let mut split: SplitVec<_, Recursive> = (0..4).collect();
     split.concurrent_reserve(5).expect("is-ok");
     let bag: ConcurrentBag<_, _> = split.into();
     assert_eq!(bag.capacity(), 4);
@@ -33,26 +28,34 @@ fn capacity() {
     assert_eq!(bag.capacity(), 5);
 }
 
-#[test]
+#[test_matrix([
+    FixedVec::new(5),
+    SplitVec::with_doubling_growth_and_fragments_capacity(1),
+    SplitVec::with_linear_growth_and_fragments_capacity(2, 1)
+])]
 #[should_panic]
-fn exceeding_fixed_capacity_panics() {
-    let mut fixed: FixedVec<_> = FixedVec::new(5);
-    fixed.extend_from_slice(&[0, 1, 2, 3]);
-    let bag: ConcurrentBag<_, _> = fixed.into();
+fn exceeding_fixed_capacity_panics<P: IntoConcurrentPinnedVec<usize>>(mut pinned_vec: P) {
+    pinned_vec.clear();
+    pinned_vec.extend_from_slice(&[0, 1, 2, 3]);
+    let bag: ConcurrentBag<_, _> = pinned_vec.into();
     assert_eq!(bag.capacity(), 5);
     bag.push(42);
     bag.push(7);
 }
 
-#[test]
+#[test_matrix([
+    FixedVec::new(10),
+    SplitVec::with_doubling_growth_and_fragments_capacity(2),
+    SplitVec::with_linear_growth_and_fragments_capacity(2, 3)
+])]
 #[should_panic]
-fn exceeding_fixed_capacity_panics_concurrently() {
-    let bag = ConcurrentBag::with_fixed_capacity(10);
+fn exceeding_fixed_capacity_panics_concurrently<P: IntoConcurrentPinnedVec<usize>>(pinned_vec: P) {
+    let bag: ConcurrentBag<_, _> = pinned_vec.into();
     let bag_ref = &bag;
     std::thread::scope(|s| {
         for _ in 0..4 {
             s.spawn(move || {
-                for _ in 0..3 {
+                for _ in 0..4 {
                     // in total there will be 4*3 = 12 pushes
                     bag_ref.push(42);
                 }
@@ -61,18 +64,30 @@ fn exceeding_fixed_capacity_panics_concurrently() {
     });
 }
 
-#[test]
-fn get() {
+#[test_matrix([
+    FixedVec::new(100),
+    SplitVec::with_doubling_growth_and_fragments_capacity(16),
+    SplitVec::with_linear_growth_and_fragments_capacity(10, 16)
+], [
+    FixedVec::new(100),
+    SplitVec::with_doubling_growth_and_fragments_capacity(16),
+    SplitVec::with_linear_growth_and_fragments_capacity(10, 16)
+])]
+fn concurrent_get_and_iter<P, Q>(pinned_i32: P, pinned_f32: Q)
+where
+    P: IntoConcurrentPinnedVec<i32> + Clone,
+    Q: IntoConcurrentPinnedVec<f32>,
+{
     // record measurements in (assume) random intervals
-    let measurements = ConcurrentBag::<i32>::new();
+    let measurements: ConcurrentBag<_, _> = pinned_i32.clone().into();
     let rf_measurements = &measurements;
 
     // collect sum of measurements every 50 milliseconds
-    let sums = ConcurrentBag::new();
+    let sums: ConcurrentBag<_, _> = pinned_i32.into();
     let rf_sums = &sums;
 
     // collect average of measurements every 50 milliseconds
-    let averages = ConcurrentBag::new();
+    let averages: ConcurrentBag<_, _> = pinned_f32.into();
     let rf_averages = &averages;
 
     std::thread::scope(|s| {
@@ -96,17 +111,16 @@ fn get() {
 
         s.spawn(move || {
             for _ in 0..10 {
-                let count = rf_measurements.len();
-                if count == 0 {
-                    rf_averages.push(0.0);
-                } else {
-                    let mut sum = 0;
-                    for i in 0..rf_measurements.len() {
-                        sum += unsafe { rf_measurements.get(i) }.copied().unwrap_or(0);
-                    }
-                    let average = sum as f32 / count as f32;
-                    rf_averages.push(average);
+                // better to have count & add as an atomic reduction for correctness
+                // calling .len() and .iter().sum() separately might possibly give a false average
+                fn count_and_add(len_and_sum: (usize, i32), x: &i32) -> (usize, i32) {
+                    (len_and_sum.0 + 1, len_and_sum.1 + x)
                 }
+
+                let (len, sum) = unsafe { rf_measurements.iter() }.fold((0, 0), count_and_add);
+                let average = sum as f32 / len as f32;
+                rf_averages.push(average);
+
                 std::thread::sleep(Duration::from_millis(50));
             }
         });
@@ -117,11 +131,16 @@ fn get() {
     assert_eq!(averages.len(), 10);
 }
 
-#[test]
-fn iter() {
-    let mut bag = ConcurrentBag::new();
+#[test_matrix([
+    FixedVec::new(10),
+    SplitVec::with_doubling_growth_and_fragments_capacity(2),
+    SplitVec::with_linear_growth_and_fragments_capacity(2, 3)
+])]
+fn get_iter<P: IntoConcurrentPinnedVec<char>>(pinned_vec: P) {
+    let mut bag: ConcurrentBag<_, _> = pinned_vec.into();
 
     assert_eq!(0, unsafe { bag.iter() }.count());
+    assert_eq!(None, unsafe { bag.get(0) });
 
     bag.push('a');
 
@@ -129,50 +148,74 @@ fn iter() {
         vec!['a'],
         unsafe { bag.iter() }.copied().collect::<Vec<_>>()
     );
+    assert_eq!(Some(&'a'), unsafe { bag.get(0) });
+    assert_eq!(None, unsafe { bag.get(1) });
 
     bag.push('b');
     bag.push('c');
     bag.push('d');
+    bag.push('e');
 
     assert_eq!(
-        vec!['a', 'b', 'c', 'd'],
+        vec!['a', 'b', 'c', 'd', 'e'],
         unsafe { bag.iter() }.copied().collect::<Vec<_>>()
     );
+    assert_eq!(Some(&'d'), unsafe { bag.get(3) });
+    assert_eq!(None, unsafe { bag.get(5) });
 
     bag.clear();
     assert_eq!(0, unsafe { bag.iter() }.count());
 }
 
-#[test]
-fn get_mut() {
-    let mut bag = ConcurrentBag::new();
+#[test_matrix([
+    FixedVec::new(10),
+    SplitVec::with_doubling_growth_and_fragments_capacity(2),
+    SplitVec::with_linear_growth_and_fragments_capacity(2, 3)
+])]
+fn get_mut<P: IntoConcurrentPinnedVec<String>>(pinned_vec: P) {
+    let mut bag: ConcurrentBag<_, _> = pinned_vec.into();
+
+    assert_eq!(None, bag.get_mut(0));
 
     bag.push("a".to_string());
     bag.push("b".to_string());
     bag.push("c".to_string());
     bag.push("d".to_string());
+    bag.push("e".to_string());
 
+    assert_eq!(None, bag.get_mut(5));
+    assert_eq!(Some("c"), bag.get_mut(2).map(|x| x.as_str()));
     *bag.get_mut(2).unwrap() = "c!".to_string();
 
     let vec: Vec<_> = unsafe { bag.iter() }.collect();
-    assert_eq!(vec, ["a", "b", "c!", "d"]);
+    assert_eq!(vec, ["a", "b", "c!", "d", "e"]);
 }
 
-#[test]
-fn iter_mut() {
-    let mut bag = ConcurrentBag::new();
+#[test_matrix([
+    FixedVec::new(10),
+    SplitVec::with_doubling_growth_and_fragments_capacity(2),
+    SplitVec::with_linear_growth_and_fragments_capacity(2, 3),
+])]
+fn iter_mut<P: IntoConcurrentPinnedVec<String>>(pinned_vec: P) {
+    let mut bag: ConcurrentBag<_, _> = pinned_vec.into();
+
+    assert_eq!(0, bag.iter_mut().count());
 
     bag.push("a".to_string());
+
+    assert_eq!(Some("a"), bag.iter_mut().next().map(|x| x.as_str()));
+
     bag.push("b".to_string());
     bag.push("c".to_string());
     bag.push("d".to_string());
+    bag.push("e".to_string());
 
     for x in bag.iter_mut().filter(|x| x.as_str() != "c") {
         *x = format!("{}!", x);
     }
 
     let vec: Vec<_> = unsafe { bag.iter() }.collect();
-    assert_eq!(vec, ["a!", "b!", "c", "d!"]);
+    assert_eq!(vec, ["a!", "b!", "c", "d!", "e!"]);
 }
 
 #[test]
@@ -192,20 +235,19 @@ fn reserve_maximum_capacity() {
     assert_eq!(bag.maximum_capacity(), 2usize.pow(10) * 20); // it can concurrently allocate 19 more
 
     // SplitVec<_, Linear> -> reserve_maximum_capacity
-    let result = bag.reserve_maximum_capacity(2usize.pow(10) * 30);
-    assert!(result.is_ok());
-    assert!(result.expect("is-ok") >= 2usize.pow(10) * 30);
+    let new_max_capacity = bag.reserve_maximum_capacity(2usize.pow(10) * 30);
+    assert!(new_max_capacity >= 2usize.pow(10) * 30);
 
     // actually no new allocation yet; precisely additional memory for 10 pairs of pointers is used
     assert_eq!(bag.capacity(), 2usize.pow(10)); // first fragment capacity
 
     assert!(bag.maximum_capacity() >= 2usize.pow(10) * 30); // now it can safely reach 2^10 * 30
 
-    // FixedVec<_>: pre-allocated, exact and strict
+    // FixedVec<_>
     let mut bag: ConcurrentBag<char, _> = ConcurrentBag::with_fixed_capacity(42);
     assert_eq!(bag.capacity(), 42);
     assert_eq!(bag.maximum_capacity(), 42);
 
-    let result = bag.reserve_maximum_capacity(43);
-    assert!(result.is_err());
+    let new_max_capacity = bag.reserve_maximum_capacity(1024);
+    assert!(new_max_capacity >= 1024);
 }

--- a/tests/push.rs
+++ b/tests/push.rs
@@ -1,11 +1,11 @@
 use orx_concurrent_bag::*;
 use orx_fixed_vec::FixedVec;
-use orx_pinned_vec::PinnedVec;
+use orx_pinned_vec::IntoConcurrentPinnedVec;
 use orx_split_vec::SplitVec;
-use std::{sync::Arc, thread, time::Duration};
+use std::time::Duration;
 use test_case::test_case;
 
-const NUM_RERUNS: usize = 4;
+const NUM_RERUNS: usize = 1;
 
 const EXHAUSTIVE_INPUTS: [(usize, usize); 15] = [
     (1, 64),
@@ -37,36 +37,7 @@ const FAST_INPUTS: [(usize, usize); 9] = [
     (8, 256),
 ];
 
-fn run_with_arc<P: PinnedVec<i32> + Clone + 'static>(
-    pinned: P,
-    num_threads: usize,
-    num_items_per_thread: usize,
-    do_sleep: bool,
-) {
-    for _ in 0..NUM_RERUNS {
-        let bag: ConcurrentBag<_, _> = pinned.clone().into();
-        let bag = Arc::new(bag);
-        let mut thread_vec: Vec<thread::JoinHandle<()>> = Vec::new();
-
-        for i in 0..num_threads {
-            let bag = bag.clone();
-            thread_vec.push(thread::spawn(move || {
-                sleep(do_sleep, i);
-                for j in 0..num_items_per_thread {
-                    bag.push((i * 100000 + j) as i32);
-                }
-            }));
-        }
-
-        for handle in thread_vec {
-            handle.join().unwrap();
-        }
-
-        assert_result(num_threads, num_items_per_thread, &bag);
-    }
-}
-
-fn run_with_scope<P: PinnedVec<i32> + Clone + 'static>(
+fn run_with_scope<P: IntoConcurrentPinnedVec<i32> + Clone + 'static>(
     pinned: P,
     num_threads: usize,
     num_items_per_thread: usize,
@@ -86,36 +57,37 @@ fn run_with_scope<P: PinnedVec<i32> + Clone + 'static>(
             }
         });
 
-        assert_result(num_threads, num_items_per_thread, &bag);
+        assert_result(num_threads, num_items_per_thread, bag.into_inner());
     }
 }
 
-fn run_test<P: PinnedVec<i32> + Clone + 'static>(pinned: P, inputs: &[(usize, usize)]) {
+fn run_test<P: IntoConcurrentPinnedVec<i32> + Clone + 'static>(
+    pinned: P,
+    inputs: &[(usize, usize)],
+) {
     for sleep in [false, true] {
         for (num_threads, num_items_per_thread) in inputs {
-            run_with_arc(pinned.clone(), *num_threads, *num_items_per_thread, sleep);
             run_with_scope(pinned.clone(), *num_threads, *num_items_per_thread, sleep);
         }
     }
 }
 
-#[test_case(FixedVec::new(524288))]
-#[test_case(SplitVec::with_doubling_growth_and_fragments_capacity(32))]
-#[test_case(SplitVec::with_recursive_growth_and_fragments_capacity(32))]
-#[test_case(SplitVec::with_linear_growth_and_fragments_capacity(6, 8192))]
-#[test_case(SplitVec::with_linear_growth_and_fragments_capacity(10, 512))]
-#[test_case(SplitVec::with_linear_growth_and_fragments_capacity(14, 32))]
-fn exhaustive<P: PinnedVec<i32> + Clone + 'static>(pinned: P) {
+// #[test_case(FixedVec::new(524288))]
+// #[test_case(SplitVec::with_doubling_growth_and_fragments_capacity(32))]
+// #[test_case(SplitVec::with_linear_growth_and_fragments_capacity(6, 8192))]
+// #[test_case(SplitVec::with_linear_growth_and_fragments_capacity(10, 512))]
+// #[test_case(SplitVec::with_linear_growth_and_fragments_capacity(14, 32))]
+#[allow(dead_code)]
+fn exhaustive<P: IntoConcurrentPinnedVec<i32> + Clone + 'static>(pinned: P) {
     run_test(pinned, &EXHAUSTIVE_INPUTS)
 }
 
 #[test_case(FixedVec::new(3000))]
 #[test_case(SplitVec::with_doubling_growth_and_fragments_capacity(32))]
-#[test_case(SplitVec::with_recursive_growth_and_fragments_capacity(32))]
 #[test_case(SplitVec::with_linear_growth_and_fragments_capacity(6, 40))]
 #[test_case(SplitVec::with_linear_growth_and_fragments_capacity(10, 10))]
 #[test_case(SplitVec::with_linear_growth_and_fragments_capacity(14, 10))]
-fn fast<P: PinnedVec<i32> + Clone + 'static>(pinned: P) {
+fn fast<P: IntoConcurrentPinnedVec<i32> + Clone + 'static>(pinned: P) {
     run_test(pinned, &FAST_INPUTS)
 }
 
@@ -128,12 +100,12 @@ fn expected_result(num_threads: usize, num_items_per_thread: usize) -> Vec<i32> 
     expected
 }
 
-fn assert_result<P: PinnedVec<i32>>(
+fn assert_result<P: IntoConcurrentPinnedVec<i32>>(
     num_threads: usize,
     num_items_per_thread: usize,
-    bag: &ConcurrentBag<i32, P>,
+    vec_from_bag: P,
 ) {
-    let mut vec_from_bag: Vec<_> = unsafe { bag.iter() }.copied().collect();
+    let mut vec_from_bag: Vec<_> = vec_from_bag.iter().copied().collect();
     vec_from_bag.sort();
 
     let expected = expected_result(num_threads, num_items_per_thread);

--- a/tests/push_out_of_capacity.rs
+++ b/tests/push_out_of_capacity.rs
@@ -1,10 +1,10 @@
 use orx_concurrent_bag::*;
 use orx_fixed_vec::FixedVec;
-use orx_pinned_vec::PinnedVec;
+use orx_pinned_vec::IntoConcurrentPinnedVec;
 use orx_split_vec::SplitVec;
 use std::time::Duration;
 
-fn run_with_scope<P: PinnedVec<i32> + Clone + 'static>(
+fn run_with_scope<P: IntoConcurrentPinnedVec<i32> + Clone + 'static>(
     pinned: P,
     num_threads: usize,
     num_items_per_thread: usize,
@@ -37,14 +37,6 @@ fn out_of_capacity_linear() {
 fn out_of_capacity_doubling() {
     let (num_threads, num_items_per_thread) = (5, 15);
     let pinned = SplitVec::with_doubling_growth_and_fragments_capacity(4); // up to 4 + 8 + 16 + 32 = 60
-    run_with_scope(pinned, num_threads, num_items_per_thread, true);
-}
-
-#[test]
-#[should_panic]
-fn out_of_capacity_recursive() {
-    let (num_threads, num_items_per_thread) = (5, 15);
-    let pinned = SplitVec::with_recursive_growth_and_fragments_capacity(4); // up to 4 + 8 + 16 + 32 = 60
     run_with_scope(pinned, num_threads, num_items_per_thread, true);
 }
 


### PR DESCRIPTION
# PinnedVec Support for Concurrency

In version 2, PinnedVec grew with new methods to support concurrent data structures. However, this caused problems since these exposed methods were often unsafe, and further, they were not directly useful for the pinned vector consumers except for concurrent data structures wrapping a pinned vector. Furthermore, they are alien to a regular vector interface that we are used to using.

In version 3, a second trait called `ConcurrentPinnedVec` is defined. All useful methods related with concurrent programming are moved to this trait. This trait has an associated type defining the underlying pinned vector type. It can be turned into the pinned vector.

Finally, `IntoConcurrentPinnedVec` trait is defined. A pinned vector implementing this trait can be turned into a `ConcurrentPinnedVec`. As explained above, it can be converted back to the pinned vector.

In this release `ConcurrentBag` wraps a `ConcurrentPinnedVec` rather than a `PinnedVec`.

With this major refactoring, safety issues are fixed to achieve a miri safe version for all the tests defined in this crate.