### PR TITLE
upgrade-pinned-vec-deps

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "orx-concurrent-bag"
-version = "3.3.0"
+version = "3.4.0"
 edition = "2024"
 authors = ["orxfun <orx.ugur.arikan@gmail.com>"]
 description = "An efficient, convenient and lightweight grow-only concurrent data structure allowing high performance concurrent collection."
@@ -11,10 +11,10 @@ categories = ["data-structures", "concurrency", "rust-patterns", "no-std"]
 
 [dependencies]
 orx-pseudo-default = { version = "2.1.0", default-features = false }
-orx-pinned-vec = { version = "3.20.0", default-features = false }
-orx-fixed-vec = { version = "3.21.0", default-features = false }
-orx-split-vec = { version = "3.21.0", default-features = false }
-orx-pinned-concurrent-col = { version = "2.17.0", default-features = false }
+orx-pinned-vec = { version = "3.21.0", default-features = false }
+orx-fixed-vec = { version = "3.22.0", default-features = false }
+orx-split-vec = { version = "3.22.0", default-features = false }
+orx-pinned-concurrent-col = { version = "2.18.0", default-features = false }
 
 [dev-dependencies]
 test-case = "3.3.1"


### PR DESCRIPTION
Upgrades PinnedVec for improved safety guarantees: https://github.com/orxfun/orx-pinned-vec/releases/tag/3.21.0
